### PR TITLE
Catch 5: rules engine, computer players, save/resume, and SwiftUI table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ DerivedData/
 build/
 .build/
 *.ipa
+work/
+.vscode/
+.swiftpm/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # CardGame.io
 
 ## Current Status
-Greenfield SwiftUI iOS app. Rules and complete hand lifecycle implemented: deal/refill, normal auction, legal moves, trick capture, scoring and match settlement. 37 tests pass, including 208 deterministic hands and a five-hand match. Match owns automatic scoring, summaries, dealer rotation and victory enforcement; terminal demo uses it. Versioned replay-based save/resume and atomic disk APIs are implemented; no automatic app lifecycle saving, strategic opponents or app UI yet.
+Greenfield SwiftUI iOS app. Rules and complete hand lifecycle implemented: deal/refill, normal auction, legal moves, trick capture, scoring and match settlement. 46 tests pass, including 208 deterministic hands and a five-hand match. Match owns automatic scoring, summaries, dealer rotation and victory enforcement; terminal demo uses it. Versioned replay-based save/resume and atomic disk APIs are implemented; baseline computer players use restricted PlayerView, with 24 shuffled match simulations. No automatic app lifecycle saving or app UI yet.
 
 ## Architecture
 Use Swift Testing and a dependency-free Swift package for rules. SwiftUI and a thin view model will consume it. Team 0 seats are 0/2, team 1 seats are 1/3; turns advance in ascending seat order modulo four.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # CardGame.io
 
 ## Current Status
-Greenfield SwiftUI iOS app. Rules and complete hand lifecycle implemented: deal/refill, normal auction, legal moves, trick capture, scoring and match settlement. 30 tests pass, including 208 deterministic hands and a five-hand match. Match owns automatic scoring, summaries, dealer rotation and victory enforcement; terminal demo uses it. No strategic opponents, persistence or app UI yet.
+Greenfield SwiftUI iOS app. Rules and complete hand lifecycle implemented: deal/refill, normal auction, legal moves, trick capture, scoring and match settlement. 37 tests pass, including 208 deterministic hands and a five-hand match. Match owns automatic scoring, summaries, dealer rotation and victory enforcement; terminal demo uses it. Versioned replay-based save/resume and atomic disk APIs are implemented; no automatic app lifecycle saving, strategic opponents or app UI yet.
 
 ## Architecture
 Use Swift Testing and a dependency-free Swift package for rules. SwiftUI and a thin view model will consume it. Team 0 seats are 0/2, team 1 seats are 1/3; turns advance in ascending seat order modulo four.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# CardGame.io
+
+## Current Status
+Greenfield SwiftUI iOS app. Rules and complete hand lifecycle implemented: deal/refill, normal auction, legal moves, trick capture, scoring and match settlement. 30 tests pass, including 208 deterministic hands and a five-hand match. Match owns automatic scoring, summaries, dealer rotation and victory enforcement; terminal demo uses it. No strategic opponents, persistence or app UI yet.
+
+## Architecture
+Use Swift Testing and a dependency-free Swift package for rules. SwiftUI and a thin view model will consume it. Team 0 seats are 0/2, team 1 seats are 1/3; turns advance in ascending seat order modulo four.
+
+## Aesthetic North Star
+A readable, welcoming card table with large cards and understated controls. Final visual design awaits the playable engine.
+
+## Verification
+Run `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test`.
+
+## Rules
+The user's house rules in `docs/catch-five-rules.md` take precedence over published Pitch rules.

--- a/App/CatchFiveApp.swift
+++ b/App/CatchFiveApp.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+import CatchFiveUI
+
+@main
+struct CatchFiveApp: App {
+    var body: some Scene {
+        WindowGroup { TableView(model: GameModel.loadDefault()) }
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/CatchFive.xcodeproj/project.pbxproj
+++ b/CatchFive.xcodeproj/project.pbxproj
@@ -1,0 +1,334 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		2B0BD89E9D1950AD6CE9D931 /* CatchFiveUI in Frameworks */ = {isa = PBXBuildFile; productRef = 8C3AEDE87BDF11591300F118 /* CatchFiveUI */; };
+		8389536425FF69B74BBC1DE5 /* CatchFiveApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0A21C058444C61FC449F3F4 /* CatchFiveApp.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		53E2688F74876BBCCCD1A00B /* cardgame-io */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "cardgame-io"; path = .; sourceTree = SOURCE_ROOT; };
+		A0A21C058444C61FC449F3F4 /* CatchFiveApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatchFiveApp.swift; sourceTree = "<group>"; };
+		F01AF627757685E129B9142A /* CatchFiveApp.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = CatchFiveApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		4E4CC33D821939219FF9EAAB /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2B0BD89E9D1950AD6CE9D931 /* CatchFiveUI in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		1F25F5D57E87C593555967D5 /* App */ = {
+			isa = PBXGroup;
+			children = (
+				A0A21C058444C61FC449F3F4 /* CatchFiveApp.swift */,
+			);
+			path = App;
+			sourceTree = "<group>";
+		};
+		69E681B29B00FBD4B2B35C3C = {
+			isa = PBXGroup;
+			children = (
+				1F25F5D57E87C593555967D5 /* App */,
+				9E1D7A103B7DCEF4FA33CF7B /* Packages */,
+				FC6EF619BD462ADC93332AA9 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		9E1D7A103B7DCEF4FA33CF7B /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				53E2688F74876BBCCCD1A00B /* cardgame-io */,
+			);
+			name = Packages;
+			sourceTree = "<group>";
+		};
+		FC6EF619BD462ADC93332AA9 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F01AF627757685E129B9142A /* CatchFiveApp.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		75BFDC222C4BB0762654E5A7 /* CatchFiveApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0FD302E4218F032E6F275379 /* Build configuration list for PBXNativeTarget "CatchFiveApp" */;
+			buildPhases = (
+				D65F07D7E6C429985A6FA0E0 /* Sources */,
+				4E4CC33D821939219FF9EAAB /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CatchFiveApp;
+			packageProductDependencies = (
+				8C3AEDE87BDF11591300F118 /* CatchFiveUI */,
+			);
+			productName = CatchFiveApp;
+			productReference = F01AF627757685E129B9142A /* CatchFiveApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		64BA1759B07DF0049DB38550 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 1430;
+				TargetAttributes = {
+					75BFDC222C4BB0762654E5A7 = {
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 27511F5CE595B8C41CE486FA /* Build configuration list for PBXProject "CatchFive" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = 69E681B29B00FBD4B2B35C3C;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				159809E2370BF38BBC47AECA /* XCLocalSwiftPackageReference "." */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = FC6EF619BD462ADC93332AA9 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				75BFDC222C4BB0762654E5A7 /* CatchFiveApp */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		D65F07D7E6C429985A6FA0E0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8389536425FF69B74BBC1DE5 /* CatchFiveApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		87BF0C235AAE9425FA02DD48 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		AE61833CD0E932B90BD3588A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		CB8E366F03350FC0323AECBA /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Catch 5";
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.cardgame.catchfive;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		EA0C412629F4B939C4EB551A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Catch 5";
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.cardgame.catchfive;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		0FD302E4218F032E6F275379 /* Build configuration list for PBXNativeTarget "CatchFiveApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EA0C412629F4B939C4EB551A /* Debug */,
+				CB8E366F03350FC0323AECBA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		27511F5CE595B8C41CE486FA /* Build configuration list for PBXProject "CatchFive" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				87BF0C235AAE9425FA02DD48 /* Debug */,
+				AE61833CD0E932B90BD3588A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		159809E2370BF38BBC47AECA /* XCLocalSwiftPackageReference "." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = .;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		8C3AEDE87BDF11591300F118 /* CatchFiveUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = CatchFiveUI;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = 64BA1759B07DF0049DB38550 /* Project object */;
+}

--- a/CatchFive.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/CatchFive.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/CatchFive.xcodeproj/xcshareddata/xcschemes/CatchFiveApp.xcscheme
+++ b/CatchFive.xcodeproj/xcshareddata/xcschemes/CatchFiveApp.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "75BFDC222C4BB0762654E5A7"
+               BuildableName = "CatchFiveApp.app"
+               BlueprintName = "CatchFiveApp"
+               ReferencedContainer = "container:CatchFive.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "75BFDC222C4BB0762654E5A7"
+            BuildableName = "CatchFiveApp.app"
+            BlueprintName = "CatchFiveApp"
+            ReferencedContainer = "container:CatchFive.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "75BFDC222C4BB0762654E5A7"
+            BuildableName = "CatchFiveApp.app"
+            BlueprintName = "CatchFiveApp"
+            ReferencedContainer = "container:CatchFive.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "75BFDC222C4BB0762654E5A7"
+            BuildableName = "CatchFiveApp.app"
+            BlueprintName = "CatchFiveApp"
+            ReferencedContainer = "container:CatchFive.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Package.swift
+++ b/Package.swift
@@ -6,10 +6,13 @@ let package = Package(
     platforms: [.iOS(.v17), .macOS(.v14)],
     products: [
         .library(name: "CatchFive", targets: ["CatchFive"]),
+        .library(name: "CatchFiveUI", targets: ["CatchFiveUI"]),
         .executable(name: "catch-five-demo", targets: ["CatchFiveDemo"])
     ],
     targets: [
         .target(name: "CatchFive"),
+        .target(name: "CatchFiveUI", dependencies: ["CatchFive"]),
+        .testTarget(name: "CatchFiveUITests", dependencies: ["CatchFiveUI", "CatchFive"]),
         .executableTarget(name: "CatchFiveDemo", dependencies: ["CatchFive"]),
         .testTarget(name: "CatchFiveTests", dependencies: ["CatchFive"])
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "CatchFive",
+    platforms: [.iOS(.v17), .macOS(.v14)],
+    products: [
+        .library(name: "CatchFive", targets: ["CatchFive"]),
+        .executable(name: "catch-five-demo", targets: ["CatchFiveDemo"])
+    ],
+    targets: [
+        .target(name: "CatchFive"),
+        .executableTarget(name: "CatchFiveDemo", dependencies: ["CatchFive"]),
+        .testTarget(name: "CatchFiveTests", dependencies: ["CatchFive"])
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,21 +1,53 @@
 # CardGame.io
 
-A free iOS app: a suite of card games (Hearts, Spades, Rummy, Poker) in one
-SwiftUI app on a shared rules engine, where each new game is a rule set, not
-a rewrite. Distributed through TestFlight; playtest feedback drove a
-rules-based AI opponent and offline play.
+A SwiftUI iOS card-game app in development, starting with Catch 5 (Pitch with Fives) using custom partnership rules and a winning score of 25.
 
-## Stack
+## Current Status
 
-Swift, SwiftUI, GameKit.
+The pure Swift engine now runs complete hands and a repeatable text demonstration runs a normal-bid match to completion. There is no playable iOS app yet.
 
-## Status
+- Normal four-seat bidding with dealer matching and forced opening bid.
+- Follow-suit validation and trick winner calculation.
+- Captured High, Low, Jack, Five, and all-suit Game scoring.
+- Normal bid settlement, 25-point wins, and 9-and-out settlement.
+- Full deal, discard/refill, bidding-to-play transitions, turn enforcement and six-trick completion.
+- Match coordinator with automatic scoring, hand history, dealer rotation and victory enforcement.
+- 30 Swift Testing tests, including 208 deterministic hands and a complete five-hand match.
 
-Code is being moved here from another machine; this README is the
-placeholder. Ask me for a walkthrough in the meantime: cmurphy1140@gmail.com.
+`Auction` currently accepts normal integer bids only. Special bid precedence awaits a house-rule clarification; 9-and-out win/loss settlement is already tested separately.
 
-## What to look for when it lands
+## Run Tests
 
-- The rules engine, and how one game's rule set plugs into it.
-- The AI opponent: rules-based, no model, readable in one file.
-- The offline-play path and how game state is saved.
+From this repository on this Mac:
+
+```sh
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
+```
+
+With Xcode selected as the default developer directory, `swift test` is sufficient. The package has no external dependencies and targets iOS 17+ / macOS 14+.
+
+## Watch a Text Match
+
+```sh
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift run catch-five-demo
+```
+
+This prints a deterministic five-hand match, ending Team 0: 26, Team 1: 16. It uses deliberately simple legal moves and ordered deck rotations for inspection, not a production shuffle or strategic opponents. No Xcode editor is needed.
+
+Initial dealing uses two packets of three starting left of dealer. Refill gives each player their replacements clockwise, starting left of dealer. These are provisional packet-order defaults.
+
+## Structure
+
+- `Sources/CatchFive`: pure Swift rules; no UI dependencies.
+- `Tests/CatchFiveTests`: repeatable rule tests with explicit card fixtures.
+- `docs/catch-five-rules.md`: confirmed house rules and unresolved cases.
+- `docs/engine-plan.md`: initial implementation milestone.
+- `docs/code-map.md`: plain-language architecture and source-to-test connections.
+
+Team-indexed inputs use `[team0, team1]`. Team 0 seats are 0/2, team 1 seats are 1/3. The Hand coordinator enforces turn order, card ownership and six-trick completion before scoring. Its read-only state includes all hands for diagnostics; a future UI/player observation layer must restrict opponents to public information. Captured-card scoring can also be used independently on supplied card collections.
+
+## Next
+
+Add computer-player strategy, save/resume, and a SwiftUI interface with a thin view model. Special-bid auction precedence remains unresolved.
+
+Development branch: `feature/catch-five-engine`. Use tested milestone commits to track progress.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ The pure Swift engine now runs complete hands and a repeatable text demonstratio
 - Full deal, discard/refill, bidding-to-play transitions, turn enforcement and six-trick completion.
 - Match coordinator with automatic scoring, hand history, dealer rotation and victory enforcement.
 - Versioned save/resume with validated action replay and atomic file writes.
-- 37 Swift Testing tests, including 208 deterministic hands and a complete five-hand match.
+- Baseline computer bidding, trump selection and card play using only a restricted PlayerView.
+- 46 Swift Testing tests, including 208 deterministic hands and 24 shuffled computer matches.
 
 `Auction` currently accepts normal integer bids only. Special bid precedence awaits a house-rule clarification; 9-and-out win/loss settlement is already tested separately.
 
@@ -37,6 +38,8 @@ This prints a deterministic five-hand match, ending Team 0: 26, Team 1: 16. It u
 
 Add `--save-roundtrip` to the demo command to see it save and restore mid-trick. Engine APIs support disk saves; automatic saving when the app closes will be connected with the UI.
 
+Add `--computer` to watch four baseline computer players complete a match with fresh shuffled decks. This mode is separate from the fixed save-roundtrip demo. The strategy is a simple heuristic, not a trained or expert player.
+
 Initial dealing uses two packets of three starting left of dealer. Refill gives each player their replacements clockwise, starting left of dealer. These are provisional packet-order defaults.
 
 ## Structure
@@ -47,10 +50,10 @@ Initial dealing uses two packets of three starting left of dealer. Refill gives 
 - `docs/engine-plan.md`: initial implementation milestone.
 - `docs/code-map.md`: plain-language architecture and source-to-test connections.
 
-Team-indexed inputs use `[team0, team1]`. Team 0 seats are 0/2, team 1 seats are 1/3. The Hand coordinator enforces turn order, card ownership and six-trick completion before scoring. Its read-only state includes all hands for diagnostics; a future UI/player observation layer must restrict opponents to public information. Captured-card scoring can also be used independently on supplied card collections.
+Team-indexed inputs use `[team0, team1]`. Team 0 seats are 0/2, team 1 seats are 1/3. The Hand coordinator enforces turn order, card ownership and six-trick completion before scoring. Its read-only state includes all hands for diagnostics; PlayerView restricts computer strategy to its own cards and public auction/trick information; the future UI must similarly keep opponents’ cards hidden. Captured-card scoring can also be used independently on supplied card collections.
 
 ## Next
 
-Add computer-player strategy and a SwiftUI interface with a thin view model. Special-bid auction precedence remains unresolved.
+Add a SwiftUI interface with a thin view model and refine computer strategy through playtesting. Special-bid auction precedence remains unresolved.
 
 Development branch: `feature/catch-five-engine`. Use tested milestone commits to track progress.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ The pure Swift engine now runs complete hands and a repeatable text demonstratio
 - Normal bid settlement, 25-point wins, and 9-and-out settlement.
 - Full deal, discard/refill, bidding-to-play transitions, turn enforcement and six-trick completion.
 - Match coordinator with automatic scoring, hand history, dealer rotation and victory enforcement.
-- 30 Swift Testing tests, including 208 deterministic hands and a complete five-hand match.
+- Versioned save/resume with validated action replay and atomic file writes.
+- 37 Swift Testing tests, including 208 deterministic hands and a complete five-hand match.
 
 `Auction` currently accepts normal integer bids only. Special bid precedence awaits a house-rule clarification; 9-and-out win/loss settlement is already tested separately.
 
@@ -34,6 +35,8 @@ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift run catch-five-de
 
 This prints a deterministic five-hand match, ending Team 0: 26, Team 1: 16. It uses deliberately simple legal moves and ordered deck rotations for inspection, not a production shuffle or strategic opponents. No Xcode editor is needed.
 
+Add `--save-roundtrip` to the demo command to see it save and restore mid-trick. Engine APIs support disk saves; automatic saving when the app closes will be connected with the UI.
+
 Initial dealing uses two packets of three starting left of dealer. Refill gives each player their replacements clockwise, starting left of dealer. These are provisional packet-order defaults.
 
 ## Structure
@@ -48,6 +51,6 @@ Team-indexed inputs use `[team0, team1]`. Team 0 seats are 0/2, team 1 seats are
 
 ## Next
 
-Add computer-player strategy, save/resume, and a SwiftUI interface with a thin view model. Special-bid auction precedence remains unresolved.
+Add computer-player strategy and a SwiftUI interface with a thin view model. Special-bid auction precedence remains unresolved.
 
 Development branch: `feature/catch-five-engine`. Use tested milestone commits to track progress.

--- a/Sources/CatchFive/Bidding.swift
+++ b/Sources/CatchFive/Bidding.swift
@@ -1,0 +1,32 @@
+public enum Bid: Equatable, Sendable {
+    case points(Int)
+    case nineAndOut
+}
+
+/// Normal bidding only. Special declaration precedence needs a house-rule decision.
+public struct Auction: Sendable {
+    public let dealer: Int
+    public private(set) var nextSeat: Int?
+    public private(set) var winner: Int?
+    public private(set) var highestBid: Int?
+
+    public init(dealer: Int) throws {
+        guard (0..<4).contains(dealer) else { throw RuleError.invalidSeat }
+        self.dealer = dealer
+        nextSeat = (dealer + 1) % 4
+    }
+
+    public mutating func act(seat: Int, bid: Int?) throws {
+        guard let nextSeat else { throw RuleError.auctionComplete }
+        guard seat == nextSeat else { throw RuleError.outOfTurn }
+        if let bid {
+            let minimum = highestBid.map { $0 + (seat == dealer ? 0 : 1) } ?? 2
+            guard (2...9).contains(bid), bid >= minimum else { throw RuleError.invalidBid }
+            highestBid = bid
+            winner = seat
+        } else if seat == dealer && highestBid == nil {
+            throw RuleError.invalidBid
+        }
+        self.nextSeat = seat == dealer ? nil : (seat + 1) % 4
+    }
+}

--- a/Sources/CatchFive/Bidding.swift
+++ b/Sources/CatchFive/Bidding.swift
@@ -3,8 +3,9 @@ public enum Bid: Equatable, Sendable {
     case nineAndOut
 }
 
-/// Normal bidding only. Special declaration precedence needs a house-rule decision.
+/// One bidding round; nine and out outranks normal nine and dealer may match.
 public struct Auction: Sendable {
+    public private(set) var isNineAndOut = false
     public let dealer: Int
     public private(set) var nextSeat: Int?
     public private(set) var winner: Int?
@@ -16,12 +17,17 @@ public struct Auction: Sendable {
         nextSeat = (dealer + 1) % 4
     }
 
-    public mutating func act(seat: Int, bid: Int?) throws {
+    public mutating func act(seat: Int, bid: Int?, nineAndOut: Bool = false) throws {
         guard let nextSeat else { throw RuleError.auctionComplete }
         guard seat == nextSeat else { throw RuleError.outOfTurn }
-        if let bid {
+        if nineAndOut {
+            guard bid == 9, !isNineAndOut || seat == dealer else { throw RuleError.invalidBid }
+            highestBid = 9
+            winner = seat
+            isNineAndOut = true
+        } else if let bid {
             let minimum = highestBid.map { $0 + (seat == dealer ? 0 : 1) } ?? 2
-            guard (2...9).contains(bid), bid >= minimum else { throw RuleError.invalidBid }
+            guard !isNineAndOut, (2...9).contains(bid), bid >= minimum else { throw RuleError.invalidBid }
             highestBid = bid
             winner = seat
         } else if seat == dealer && highestBid == nil {

--- a/Sources/CatchFive/Cards.swift
+++ b/Sources/CatchFive/Cards.swift
@@ -1,0 +1,33 @@
+public enum Suit: String, CaseIterable, Codable, Sendable {
+    case clubs, diamonds, hearts, spades
+}
+
+public enum Rank: Int, CaseIterable, Codable, Sendable {
+    case two = 2, three, four, five, six, seven, eight, nine, ten, jack, queen, king, ace
+
+    public var gameValue: Int {
+        switch self {
+        case .ten: 10
+        case .jack: 1
+        case .queen: 2
+        case .king: 3
+        case .ace: 4
+        default: 0
+        }
+    }
+}
+
+public struct Card: Hashable, Codable, Sendable {
+    public let suit: Suit
+    public let rank: Rank
+
+    public init(_ suit: Suit, _ rank: Rank) {
+        self.suit = suit
+        self.rank = rank
+    }
+}
+
+public enum RuleError: Error, Equatable {
+    case invalidTrick, invalidSeat, outOfTurn, invalidBid, auctionComplete
+    case invalidScoring, forbiddenNineAndOut
+}

--- a/Sources/CatchFive/ComputerPlayer.swift
+++ b/Sources/CatchFive/ComputerPlayer.swift
@@ -1,0 +1,105 @@
+/// Only this player's cards and public information cross the strategy boundary.
+public struct PlayerView: Sendable {
+    public let seat: Int
+    public let cards: [Card]
+    public let phase: HandPhase
+    public let nextSeat: Int?
+    public let dealer: Int
+    public let highestBid: Int?
+    public let bidder: Int?
+    public let trump: Suit?
+    public let trick: [Play]
+}
+
+extension PlayerView {
+    public init(match: Match, seat: Int) throws {
+        guard (0..<4).contains(seat) else { throw RuleError.invalidSeat }
+        let hand = match.hand
+        self.init(seat: seat, cards: hand.hands[seat], phase: hand.phase,
+                  nextSeat: match.winner == nil ? hand.nextSeat : nil,
+                  dealer: hand.auction.dealer, highestBid: hand.auction.highestBid,
+                  bidder: hand.auction.winner, trump: hand.trump, trick: hand.currentTrick)
+    }
+}
+
+public enum PlayerAction: Equatable, Sendable {
+    case bid(Int?)
+    case chooseTrump(Suit)
+    case play(Card)
+}
+
+public enum ComputerPlayer {
+    public static func decide(_ view: PlayerView) -> PlayerAction? {
+        guard view.nextSeat == view.seat else { return nil }
+        switch view.phase {
+        case .bidding: return .bid(bidAmount(view))
+        case .choosingTrump: return .chooseTrump(preferredSuit(view.cards))
+        case .playing: return chooseCard(view).map(PlayerAction.play)
+        case .finished: return nil
+        }
+    }
+
+    private static func preferredSuit(_ cards: [Card]) -> Suit {
+        // Fixed suit order makes equal-strength choices repeatable.
+        Suit.allCases.max { strength(cards, suit: $0) < strength(cards, suit: $1) } ?? .clubs
+    }
+
+    private static func strength(_ cards: [Card], suit: Suit) -> Int {
+        cards.filter { $0.suit == suit }.reduce(0) { total, card in
+            total + 2 + (card.rank.rawValue >= Rank.jack.rawValue ? 2 : 0)
+                + (card.rank == .five ? 2 : 0)
+        }
+    }
+
+    private static func bidAmount(_ view: PlayerView) -> Int? {
+        if let bidder = view.bidder, bidder % 2 == view.seat % 2 { return nil }
+        let needed = view.highestBid.map { $0 + (view.seat == view.dealer ? 0 : 1) } ?? 2
+        let confidence = min(5, strength(view.cards, suit: preferredSuit(view.cards)) / 3)
+        if needed <= confidence { return needed }
+        if view.seat == view.dealer && view.highestBid == nil { return 2 }
+        return nil
+    }
+
+    private static func chooseCard(_ view: PlayerView) -> Card? {
+        guard let trump = view.trump else { return nil }
+        let legal = legalCards(in: view.cards, led: view.trick.first?.card.suit)
+        guard let lead = view.trick.first else {
+            // Lead a high card to gain control; this is a baseline heuristic.
+            return legal.max { rank($0, led: trump, trump: trump) < rank($1, led: trump, trump: trump) }
+        }
+        let current = view.trick.max { rank($0.card, led: lead.card.suit, trump: trump)
+            < rank($1.card, led: lead.card.suit, trump: trump) }!
+        let partnerWinning = current.seat % 2 == view.seat % 2
+        if partnerWinning && view.trick.count == 3 {
+            return legal.max { value($0, trump: trump) < value($1, trump: trump) }
+        }
+        if !partnerWinning {
+            let winning = legal.filter { rank($0, led: lead.card.suit, trump: trump)
+                > rank(current.card, led: lead.card.suit, trump: trump) }
+            if let cheapest = winning.min(by: { rank($0, led: lead.card.suit, trump: trump)
+                < rank($1, led: lead.card.suit, trump: trump) }) { return cheapest }
+        }
+        return legal.min { value($0, trump: trump) < value($1, trump: trump) }
+    }
+
+    private static func rank(_ card: Card, led: Suit, trump: Suit) -> Int {
+        let tier = card.suit == trump ? 200 : (card.suit == led ? 100 : 0)
+        return tier + card.rank.rawValue
+    }
+
+    private static func value(_ card: Card, trump: Suit) -> Int {
+        let bonus = card.suit == trump ? (card.rank == .five ? 500 : 30) : 0
+        return bonus + card.rank.gameValue * 10 + card.rank.rawValue
+    }
+}
+
+extension Match {
+    /// Human and computer actions use the same checked entry points.
+    public mutating func apply(_ action: PlayerAction, seat: Int) throws {
+        switch action {
+        case let .bid(amount): try bid(seat: seat, amount: amount)
+        case let .chooseTrump(suit): try chooseTrump(seat: seat, suit: suit)
+        case let .play(card): try play(seat: seat, card: card)
+        }
+    }
+}

--- a/Sources/CatchFive/ComputerPlayer.swift
+++ b/Sources/CatchFive/ComputerPlayer.swift
@@ -23,6 +23,7 @@ extension PlayerView {
 }
 
 public enum PlayerAction: Equatable, Sendable {
+    case nineAndOut
     case bid(Int?)
     case chooseTrump(Suit)
     case play(Card)
@@ -97,6 +98,7 @@ extension Match {
     /// Human and computer actions use the same checked entry points.
     public mutating func apply(_ action: PlayerAction, seat: Int) throws {
         switch action {
+        case .nineAndOut: try bidNineAndOut(seat: seat)
         case let .bid(amount): try bid(seat: seat, amount: amount)
         case let .chooseTrump(suit): try chooseTrump(seat: seat, suit: suit)
         case let .play(card): try play(seat: seat, card: card)

--- a/Sources/CatchFive/Hand.swift
+++ b/Sources/CatchFive/Hand.swift
@@ -1,0 +1,97 @@
+public enum HandPhase: Sendable {
+    case bidding, choosingTrump, playing, finished
+}
+
+public struct CompletedTrick: Sendable {
+    public let plays: [Play]
+    public let winner: Int
+}
+
+public enum HandError: Error, Equatable {
+    case invalidDeck, wrongPhase, notBidWinner, cardNotHeld, mustFollowSuit
+}
+
+public struct Hand: Sendable {
+    public private(set) var phase: HandPhase = .bidding
+    public private(set) var auction: Auction
+    public private(set) var hands: [[Card]] = [[], [], [], []]
+    public private(set) var stock: [Card]
+    public private(set) var discarded: [Card] = []
+    public private(set) var trump: Suit?
+    public private(set) var nextSeat: Int?
+    public private(set) var currentTrick: [Play] = []
+    public private(set) var completedTricks: [CompletedTrick] = []
+    public private(set) var captured: [[Card]] = [[], []]
+    public private(set) var result: HandScore?
+
+    /// Supply a shuffled deck for play or a fixed deck for repeatable tests.
+    public init(deck: [Card], dealer: Int) throws {
+        auction = try Auction(dealer: dealer)
+        guard deck.count == 52, Set(deck).count == 52 else { throw HandError.invalidDeck }
+        stock = deck
+        for _ in 0..<2 {
+            for offset in 1...4 {
+                let seat = (dealer + offset) % 4
+                hands[seat].append(contentsOf: stock.prefix(3))
+                stock.removeFirst(3)
+            }
+        }
+        nextSeat = auction.nextSeat
+    }
+
+    public mutating func bid(seat: Int, amount: Int?) throws {
+        guard phase == .bidding else { throw HandError.wrongPhase }
+        try auction.act(seat: seat, bid: amount)
+        nextSeat = auction.nextSeat
+        if nextSeat == nil {
+            phase = .choosingTrump
+            nextSeat = auction.winner
+        }
+    }
+    public mutating func chooseTrump(seat: Int, suit: Suit) throws {
+        guard phase == .choosingTrump else { throw HandError.wrongPhase }
+        guard seat == auction.winner else { throw HandError.notBidWinner }
+        trump = suit
+        for offset in 1...4 {
+            let player = (auction.dealer + offset) % 4
+            discarded.append(contentsOf: hands[player].filter { $0.suit != suit })
+            hands[player].removeAll { $0.suit != suit }
+            let needed = 6 - hands[player].count
+            hands[player].append(contentsOf: stock.prefix(needed))
+            stock.removeFirst(needed)
+        }
+        phase = .playing
+        nextSeat = seat
+    }
+    public mutating func play(seat: Int, card: Card) throws {
+        guard phase == .playing else { throw HandError.wrongPhase }
+        guard seat == nextSeat else { throw RuleError.outOfTurn }
+        guard let index = hands[seat].firstIndex(of: card) else { throw HandError.cardNotHeld }
+        guard legalMoves(seat: seat).contains(card) else { throw HandError.mustFollowSuit }
+        // Work on a copy so even a failed trick/scoring validation leaves the hand untouched.
+        var updated = self
+        updated.hands[seat].remove(at: index)
+        updated.currentTrick.append(Play(seat: seat, card: card))
+        updated.nextSeat = (seat + 1) % 4
+        if updated.currentTrick.count == 4 { try updated.finishTrick() }
+        self = updated
+    }
+
+    private mutating func finishTrick() throws {
+        guard let trump, let bidder = auction.winner else { throw HandError.wrongPhase }
+        let winner = try trickWinner(currentTrick, trump: trump)
+        completedTricks.append(CompletedTrick(plays: currentTrick, winner: winner))
+        captured[winner % 2].append(contentsOf: currentTrick.map(\.card))
+        currentTrick = []
+        nextSeat = winner
+        if completedTricks.count == 6 {
+            result = try scoreHand(captured: captured, trump: trump, bidder: bidder % 2)
+            phase = .finished
+            nextSeat = nil
+        }
+    }
+    public func legalMoves(seat: Int) -> [Card] {
+        guard phase == .playing, nextSeat == seat, (0..<4).contains(seat) else { return [] }
+        return legalCards(in: hands[seat], led: currentTrick.first?.card.suit)
+    }
+}

--- a/Sources/CatchFive/Hand.swift
+++ b/Sources/CatchFive/Hand.swift
@@ -39,9 +39,9 @@ public struct Hand: Sendable {
         nextSeat = auction.nextSeat
     }
 
-    public mutating func bid(seat: Int, amount: Int?) throws {
+    public mutating func bid(seat: Int, amount: Int?, nineAndOut: Bool = false) throws {
         guard phase == .bidding else { throw HandError.wrongPhase }
-        try auction.act(seat: seat, bid: amount)
+        try auction.act(seat: seat, bid: amount, nineAndOut: nineAndOut)
         nextSeat = auction.nextSeat
         if nextSeat == nil {
             phase = .choosingTrump

--- a/Sources/CatchFive/Match.swift
+++ b/Sources/CatchFive/Match.swift
@@ -1,0 +1,59 @@
+public enum MatchError: Error, Equatable {
+    case handInProgress, matchFinished
+}
+
+public struct HandSummary: Sendable {
+    public let number: Int
+    public let dealer: Int
+    public let bidder: Int
+    public let bid: Int
+    public let result: HandScore
+    public let scores: [Int]
+}
+
+/// Owns the whole game. All player actions pass through the current Hand's rules.
+public struct Match: Sendable {
+    public private(set) var hand: Hand
+    public private(set) var scores = [0, 0]
+    public private(set) var winner: Int?
+    public private(set) var history: [HandSummary] = []
+    public private(set) var handNumber = 1
+
+    public init(deck: [Card], dealer: Int) throws {
+        hand = try Hand(deck: deck, dealer: dealer)
+    }
+
+    public mutating func bid(seat: Int, amount: Int?) throws {
+        guard winner == nil else { throw MatchError.matchFinished }
+        try hand.bid(seat: seat, amount: amount)
+    }
+    public mutating func chooseTrump(seat: Int, suit: Suit) throws {
+        guard winner == nil else { throw MatchError.matchFinished }
+        try hand.chooseTrump(seat: seat, suit: suit)
+    }
+    public mutating func play(seat: Int, card: Card) throws {
+        guard winner == nil else { throw MatchError.matchFinished }
+        var updated = self
+        try updated.hand.play(seat: seat, card: card)
+        if updated.hand.phase == .finished { try updated.recordHand() }
+        self = updated
+    }
+
+    private mutating func recordHand() throws {
+        guard let result = hand.result, let bidder = hand.auction.winner,
+              let amount = hand.auction.highestBid else { throw HandError.wrongPhase }
+        let outcome = try settle(scores: scores, points: result.points,
+                                 bidder: bidder % 2, bid: .points(amount))
+        scores = outcome.scores
+        winner = outcome.winner
+        history.append(HandSummary(number: handNumber, dealer: hand.auction.dealer,
+                                   bidder: bidder, bid: amount, result: result, scores: scores))
+    }
+    public mutating func startNextHand(deck: [Card]) throws {
+        guard winner == nil else { throw MatchError.matchFinished }
+        guard hand.phase == .finished else { throw MatchError.handInProgress }
+        let next = try Hand(deck: deck, dealer: (hand.auction.dealer + 1) % 4)
+        hand = next
+        handNumber += 1
+    }
+}

--- a/Sources/CatchFive/Match.swift
+++ b/Sources/CatchFive/Match.swift
@@ -7,6 +7,7 @@ public struct HandSummary: Sendable {
     public let dealer: Int
     public let bidder: Int
     public let bid: Int
+    public let isNineAndOut: Bool
     public let result: HandScore
     public let scores: [Int]
 }
@@ -33,6 +34,14 @@ public struct Match: Sendable {
         try hand.bid(seat: seat, amount: amount)
         actions.append(.bid(seat: seat, amount: amount))
     }
+    public mutating func bidNineAndOut(seat: Int) throws {
+        guard winner == nil else { throw MatchError.matchFinished }
+        guard (0..<4).contains(seat) else { throw RuleError.invalidSeat }
+        guard scores[seat % 2] >= 0 else { throw RuleError.forbiddenNineAndOut }
+        try hand.bid(seat: seat, amount: 9, nineAndOut: true)
+        actions.append(.nineAndOut(seat: seat))
+    }
+
     public mutating func chooseTrump(seat: Int, suit: Suit) throws {
         guard winner == nil else { throw MatchError.matchFinished }
         try hand.chooseTrump(seat: seat, suit: suit)
@@ -51,11 +60,11 @@ public struct Match: Sendable {
         guard let result = hand.result, let bidder = hand.auction.winner,
               let amount = hand.auction.highestBid else { throw HandError.wrongPhase }
         let outcome = try settle(scores: scores, points: result.points,
-                                 bidder: bidder % 2, bid: .points(amount))
+                                 bidder: bidder % 2, bid: hand.auction.isNineAndOut ? .nineAndOut : .points(amount))
         scores = outcome.scores
         winner = outcome.winner
         history.append(HandSummary(number: handNumber, dealer: hand.auction.dealer,
-                                   bidder: bidder, bid: amount, result: result, scores: scores))
+                                   bidder: bidder, bid: amount, isNineAndOut: hand.auction.isNineAndOut, result: result, scores: scores))
     }
     public mutating func startNextHand(deck: [Card]) throws {
         guard winner == nil else { throw MatchError.matchFinished }

--- a/Sources/CatchFive/Match.swift
+++ b/Sources/CatchFive/Match.swift
@@ -18,24 +18,32 @@ public struct Match: Sendable {
     public private(set) var winner: Int?
     public private(set) var history: [HandSummary] = []
     public private(set) var handNumber = 1
+    let initialDeck: [Card]
+    let initialDealer: Int
+    private(set) var actions: [SavedAction] = []
 
     public init(deck: [Card], dealer: Int) throws {
         hand = try Hand(deck: deck, dealer: dealer)
+        initialDeck = deck
+        initialDealer = dealer
     }
 
     public mutating func bid(seat: Int, amount: Int?) throws {
         guard winner == nil else { throw MatchError.matchFinished }
         try hand.bid(seat: seat, amount: amount)
+        actions.append(.bid(seat: seat, amount: amount))
     }
     public mutating func chooseTrump(seat: Int, suit: Suit) throws {
         guard winner == nil else { throw MatchError.matchFinished }
         try hand.chooseTrump(seat: seat, suit: suit)
+        actions.append(.trump(seat: seat, suit: suit))
     }
     public mutating func play(seat: Int, card: Card) throws {
         guard winner == nil else { throw MatchError.matchFinished }
         var updated = self
         try updated.hand.play(seat: seat, card: card)
         if updated.hand.phase == .finished { try updated.recordHand() }
+        updated.actions.append(.play(seat: seat, card: card))
         self = updated
     }
 
@@ -55,5 +63,6 @@ public struct Match: Sendable {
         let next = try Hand(deck: deck, dealer: (hand.auction.dealer + 1) % 4)
         hand = next
         handNumber += 1
+        actions.append(.nextHand(deck: deck))
     }
 }

--- a/Sources/CatchFive/MatchSave.swift
+++ b/Sources/CatchFive/MatchSave.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+public enum SaveError: Error, Equatable {
+    case invalidData, unsupportedVersion(Int)
+}
+
+enum SavedAction: Codable, Sendable {
+    case bid(seat: Int, amount: Int?)
+    case trump(seat: Int, suit: Suit)
+    case play(seat: Int, card: Card)
+    case nextHand(deck: [Card])
+
+    func apply(to match: inout Match) throws {
+        switch self {
+        case let .bid(seat, amount): try match.bid(seat: seat, amount: amount)
+        case let .trump(seat, suit): try match.chooseTrump(seat: seat, suit: suit)
+        case let .play(seat, card): try match.play(seat: seat, card: card)
+        case let .nextHand(deck): try match.startNextHand(deck: deck)
+        }
+    }
+}
+
+private struct Archive: Codable {
+    let version: Int
+    let initialDeck: [Card]
+    let initialDealer: Int
+    let actions: [SavedAction]
+}
+
+/// Versioned local saves. Replay validates actions through the ordinary rules.
+public enum MatchSave {
+    public static func encode(_ match: Match) throws -> Data {
+        let archive = Archive(version: 1, initialDeck: match.initialDeck,
+                              initialDealer: match.initialDealer, actions: match.actions)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(archive)
+    }
+
+    public static func decode(_ data: Data) throws -> Match {
+        do {
+            let archive = try JSONDecoder().decode(Archive.self, from: data)
+            guard archive.version == 1 else { throw SaveError.unsupportedVersion(archive.version) }
+            var match = try Match(deck: archive.initialDeck, dealer: archive.initialDealer)
+            for action in archive.actions { try action.apply(to: &match) }
+            return match
+        } catch let error as SaveError {
+            throw error
+        } catch {
+            throw SaveError.invalidData
+        }
+    }
+
+    /// Atomic replacement preserves the previous save if replacement cannot complete.
+    public static func write(_ match: Match, to url: URL) throws {
+        try encode(match).write(to: url, options: .atomic)
+    }
+
+    public static func read(from url: URL) throws -> Match {
+        try decode(Data(contentsOf: url))
+    }
+}

--- a/Sources/CatchFive/MatchSave.swift
+++ b/Sources/CatchFive/MatchSave.swift
@@ -5,6 +5,7 @@ public enum SaveError: Error, Equatable {
 }
 
 enum SavedAction: Codable, Sendable {
+    case nineAndOut(seat: Int)
     case bid(seat: Int, amount: Int?)
     case trump(seat: Int, suit: Suit)
     case play(seat: Int, card: Card)
@@ -12,6 +13,7 @@ enum SavedAction: Codable, Sendable {
 
     func apply(to match: inout Match) throws {
         switch self {
+        case let .nineAndOut(seat): try match.bidNineAndOut(seat: seat)
         case let .bid(seat, amount): try match.bid(seat: seat, amount: amount)
         case let .trump(seat, suit): try match.chooseTrump(seat: seat, suit: suit)
         case let .play(seat, card): try match.play(seat: seat, card: card)

--- a/Sources/CatchFive/Scoring.swift
+++ b/Sources/CatchFive/Scoring.swift
@@ -1,0 +1,58 @@
+public struct HandScore: Equatable, Sendable {
+    public let points: [Int]
+    public let gameValues: [Int]
+    public let highTeam: Int?
+    public let lowTeam: Int?
+    public let jackTeam: Int?
+    public let fiveTeam: Int?
+    public let gameTeam: Int
+}
+
+public struct Settlement: Equatable, Sendable {
+    public let scores: [Int]
+    public let winner: Int?
+}
+
+/// Captured cards grouped by partnership. Undealt cards must not be included.
+public func scoreHand(captured: [[Card]], trump: Suit, bidder: Int) throws -> HandScore {
+    guard captured.count == 2, (0..<2).contains(bidder) else { throw RuleError.invalidScoring }
+    let cards = captured.flatMap { $0 }
+    guard Set(cards).count == cards.count else { throw RuleError.invalidScoring }
+    let trumps = cards.filter { $0.suit == trump }
+    let high = trumps.max { $0.rank.rawValue < $1.rank.rawValue }
+    let low = trumps.min { $0.rank.rawValue < $1.rank.rawValue }
+    func owner(of card: Card?) -> Int? {
+        guard let card else { return nil }
+        return captured.firstIndex { $0.contains(card) }
+    }
+    let highTeam = owner(of: high)
+    let lowTeam = owner(of: low)
+    let jackTeam = owner(of: Card(trump, .jack))
+    let fiveTeam = owner(of: Card(trump, .five))
+    let values = captured.map { $0.reduce(0) { $0 + $1.rank.gameValue } }
+    let gameTeam = values[0] == values[1] ? bidder : (values[0] > values[1] ? 0 : 1)
+    var points = [0, 0]
+    for team in [highTeam, lowTeam, jackTeam].compactMap({ $0 }) { points[team] += 1 }
+    if let fiveTeam { points[fiveTeam] += 5 }
+    points[gameTeam] += 1
+    return HandScore(points: points, gameValues: values, highTeam: highTeam,
+                     lowTeam: lowTeam, jackTeam: jackTeam, fiveTeam: fiveTeam, gameTeam: gameTeam)
+}
+
+public func settle(scores: [Int], points: [Int], bidder: Int, bid: Bid) throws -> Settlement {
+    guard scores.count == 2, points.count == 2, (0..<2).contains(bidder),
+          points.allSatisfy({ (0...9).contains($0) }), points.reduce(0, +) <= 9 else {
+        throw RuleError.invalidScoring
+    }
+    if bid == .nineAndOut {
+        guard scores[bidder] >= 0 else { throw RuleError.forbiddenNineAndOut }
+        // Match ends immediately; retain pre-hand scores rather than invent a special numeric bonus.
+        return Settlement(scores: scores, winner: points[bidder] == 9 ? bidder : 1 - bidder)
+    }
+    guard case let .points(amount) = bid, (2...9).contains(amount) else { throw RuleError.invalidBid }
+    var updated = scores
+    updated[bidder] += points[bidder] >= amount ? points[bidder] : -amount
+    updated[1 - bidder] += points[1 - bidder]
+    let winner = updated[bidder] >= 25 ? bidder : (updated[1 - bidder] >= 25 ? 1 - bidder : nil)
+    return Settlement(scores: updated, winner: winner)
+}

--- a/Sources/CatchFive/Tricks.swift
+++ b/Sources/CatchFive/Tricks.swift
@@ -1,0 +1,26 @@
+public struct Play: Equatable, Sendable {
+    public let seat: Int
+    public let card: Card
+
+    public init(seat: Int, card: Card) {
+        self.seat = seat
+        self.card = card
+    }
+}
+
+public func legalCards(in hand: [Card], led: Suit?) -> [Card] {
+    guard let led else { return hand }
+    let following = hand.filter { $0.suit == led }
+    return following.isEmpty ? hand : following
+}
+
+public func trickWinner(_ plays: [Play], trump: Suit) throws -> Int {
+    guard plays.count == 4,
+          Set(plays.map(\.seat)) == Set(0..<4),
+          Set(plays.map(\.card)).count == 4 else { throw RuleError.invalidTrick }
+    let led = plays[0].card.suit
+    let trumps = plays.filter { $0.card.suit == trump }
+    let candidates = trumps.isEmpty ? plays.filter { $0.card.suit == led } : trumps
+    // There is always at least the leading card, or one trump.
+    return candidates.max { $0.card.rank.rawValue < $1.card.rank.rawValue }!.seat
+}

--- a/Sources/CatchFiveDemo/ComputerDemo.swift
+++ b/Sources/CatchFiveDemo/ComputerDemo.swift
@@ -18,6 +18,7 @@ func runComputerMatch() throws {
             throw DemoError.noLegalMove
         }
         switch action {
+        case .nineAndOut: print("Seat \(seat): 9 and out")
         case let .bid(amount): print("Seat \(seat): \(amount.map { "bid \($0)" } ?? "pass")")
         case let .chooseTrump(suit): print("Seat \(seat): trump is \(suit.rawValue)")
         case let .play(card): print("Seat \(seat): \(label(card))")

--- a/Sources/CatchFiveDemo/ComputerDemo.swift
+++ b/Sources/CatchFiveDemo/ComputerDemo.swift
@@ -1,0 +1,28 @@
+import CatchFive
+
+func runComputerMatch() throws {
+    var match = try Match(deck: deck.shuffled(), dealer: 3)
+    print("CATCH 5 — four computer players, shuffled deck")
+    for _ in 0..<10000 {
+        if let winner = match.winner {
+            print("WINNER: Team \(winner), scores \(match.scores), after \(match.handNumber) hands.")
+            return
+        }
+        if match.hand.phase == .finished {
+            print("Hand \(match.handNumber): points \(match.hand.result!.points), running scores \(match.scores)")
+            try match.startNextHand(deck: deck.shuffled())
+            continue
+        }
+        guard let seat = match.hand.nextSeat,
+              let action = ComputerPlayer.decide(try PlayerView(match: match, seat: seat)) else {
+            throw DemoError.noLegalMove
+        }
+        switch action {
+        case let .bid(amount): print("Seat \(seat): \(amount.map { "bid \($0)" } ?? "pass")")
+        case let .chooseTrump(suit): print("Seat \(seat): trump is \(suit.rawValue)")
+        case let .play(card): print("Seat \(seat): \(label(card))")
+        }
+        try match.apply(action, seat: seat)
+    }
+    throw DemoError.matchDidNotFinish
+}

--- a/Sources/CatchFiveDemo/main.swift
+++ b/Sources/CatchFiveDemo/main.swift
@@ -1,0 +1,69 @@
+import CatchFive
+
+// This is a repeatable diagnostic demonstration, not the computer-player strategy.
+let deck = Suit.allCases.flatMap { suit in Rank.allCases.map { Card(suit, $0) } }
+
+func label(_ card: Card) -> String {
+    let rank: String
+    switch card.rank {
+    case .jack: rank = "J"
+    case .queen: rank = "Q"
+    case .king: rank = "K"
+    case .ace: rank = "A"
+    default: rank = String(card.rank.rawValue)
+    }
+    return "\(rank) of \(card.suit.rawValue)"
+}
+
+func owner(_ team: Int?) -> String {
+    team.map { "Team \($0)" } ?? "out of play"
+}
+
+func deckForHand(_ number: Int) -> [Card] {
+    let rotation = (number * 7) % 52
+    return Array(deck[rotation...]) + Array(deck[..<rotation])
+}
+
+func runHand(in match: inout Match) throws {
+    let number = match.handNumber
+    let dealer = match.hand.auction.dealer
+    let bidder = (dealer + 1) % 4
+    print("\nHAND \(number) | Dealer: Seat \(dealer)")
+    try match.bid(seat: bidder, amount: 2)
+    for offset in 1...3 { try match.bid(seat: (bidder + offset) % 4, amount: nil) }
+    let trump = Suit.allCases[number % 4]
+    try match.chooseTrump(seat: bidder, suit: trump)
+    print("Seat \(bidder) bids 2; others pass. Trump: \(trump.rawValue).")
+    print("Refill complete: \(match.hand.stock.count) undealt, \(match.hand.discarded.count) discarded.")
+    while let seat = match.hand.nextSeat {
+        guard let card = match.hand.legalMoves(seat: seat).first else { throw DemoError.noLegalMove }
+        try match.play(seat: seat, card: card)
+        if match.hand.currentTrick.isEmpty, let trick = match.hand.completedTricks.last {
+            let plays = trick.plays.map { "Seat \($0.seat): \(label($0.card))" }.joined(separator: " | ")
+            print("Trick \(match.hand.completedTricks.count): \(plays) -> Seat \(trick.winner)")
+        }
+    }
+}
+
+enum DemoError: Error { case noLegalMove, incompleteHand, matchDidNotFinish }
+
+func runMatch() throws {
+    var match = try Match(deck: deckForHand(1), dealer: 3)
+    print("CATCH 5 — automated text demonstration")
+    print("Team 0: seats 0/2. Team 1: seats 1/3. First to 25.")
+    for number in 1...200 {
+        if number > 1 { try match.startNextHand(deck: deckForHand(number)) }
+        try runHand(in: &match)
+        guard let result = match.hand.result else { throw DemoError.incompleteHand }
+        print("High: \(owner(result.highTeam)); Low: \(owner(result.lowTeam)); Jack: \(owner(result.jackTeam)); Five: \(owner(result.fiveTeam))")
+        print("Game values: \(result.gameValues), awarded to Team \(result.gameTeam). Hand points: \(result.points)")
+        print("Running score — Team 0: \(match.scores[0]), Team 1: \(match.scores[1])")
+        if let winner = match.winner {
+            print("\nWINNER: Team \(winner) after \(number) hands.")
+            return
+        }
+    }
+    throw DemoError.matchDidNotFinish
+}
+
+try runMatch()

--- a/Sources/CatchFiveDemo/main.swift
+++ b/Sources/CatchFiveDemo/main.swift
@@ -72,4 +72,8 @@ func runMatch() throws {
     throw DemoError.matchDidNotFinish
 }
 
-try runMatch()
+if CommandLine.arguments.contains("--computer") {
+    try runComputerMatch()
+} else {
+    try runMatch()
+}

--- a/Sources/CatchFiveDemo/main.swift
+++ b/Sources/CatchFiveDemo/main.swift
@@ -38,6 +38,12 @@ func runHand(in match: inout Match) throws {
     while let seat = match.hand.nextSeat {
         guard let card = match.hand.legalMoves(seat: seat).first else { throw DemoError.noLegalMove }
         try match.play(seat: seat, card: card)
+        if CommandLine.arguments.contains("--save-roundtrip"), number == 1,
+           match.hand.completedTricks.isEmpty, match.hand.currentTrick.count == 3 {
+            let data = try MatchSave.encode(match)
+            match = try MatchSave.decode(data)
+            print("SAVE/RESUME: restored three cards on the table; Seat \(match.hand.nextSeat!) acts next.")
+        }
         if match.hand.currentTrick.isEmpty, let trick = match.hand.completedTricks.last {
             let plays = trick.plays.map { "Seat \($0.seat): \(label($0.card))" }.joined(separator: " | ")
             print("Trick \(match.hand.completedTricks.count): \(plays) -> Seat \(trick.winner)")

--- a/Sources/CatchFiveUI/CardView.swift
+++ b/Sources/CatchFiveUI/CardView.swift
@@ -1,0 +1,50 @@
+import CatchFive
+import SwiftUI
+
+extension Suit {
+    var glyph: String {
+        switch self {
+        case .clubs: "♣"
+        case .diamonds: "♦"
+        case .hearts: "♥"
+        case .spades: "♠"
+        }
+    }
+    var ink: Color { self == .hearts || self == .diamonds ? Color(red: 0.7, green: 0.12, blue: 0.18) : .black }
+}
+
+extension Card {
+    var label: String {
+        switch rank {
+        case .ace: "A"
+        case .king: "K"
+        case .queen: "Q"
+        case .jack: "J"
+        default: String(rank.rawValue)
+        }
+    }
+    var spoken: String { "\(label) of \(suit.rawValue)" }
+}
+
+struct CardView: View {
+    let card: Card
+    var body: some View {
+        VStack(spacing: 0) {
+            Text(card.label).font(.system(size: 23, weight: .bold, design: .serif))
+            Text(card.suit.glyph).font(.system(size: 27))
+        }
+        .foregroundStyle(card.suit.ink)
+        .frame(width: 48, height: 72)
+        .background(.ivory, in: RoundedRectangle(cornerRadius: 8))
+        .overlay(RoundedRectangle(cornerRadius: 8).stroke(.black.opacity(0.15)))
+        .shadow(color: .black.opacity(0.25), radius: 3, y: 3)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(card.spoken)
+    }
+}
+
+extension ShapeStyle where Self == Color {
+    static var ivory: Color { Color(red: 0.98, green: 0.96, blue: 0.89) }
+    static var felt: Color { Color(red: 0.035, green: 0.16, blue: 0.13) }
+    static var gold: Color { Color(red: 0.91, green: 0.75, blue: 0.42) }
+}

--- a/Sources/CatchFiveUI/GameModel.swift
+++ b/Sources/CatchFiveUI/GameModel.swift
@@ -1,0 +1,78 @@
+import CatchFive
+import Combine
+import Foundation
+
+@MainActor
+public final class GameModel: ObservableObject {
+    @Published public private(set) var match: Match
+    @Published public private(set) var revision = 0
+    @Published public var errorMessage: String?
+    private let saveURL: URL?
+
+    public init(match: Match, saveURL: URL? = nil) {
+        self.match = match
+        self.saveURL = saveURL
+    }
+
+    public var isHumanTurn: Bool { match.winner == nil && match.hand.nextSeat == 0 }
+    public var humanCards: [Card] { match.hand.hands[0] }
+    public func send(_ action: PlayerAction) {
+        guard isHumanTurn else { return }
+        perform { try match.apply(action, seat: 0) }
+    }
+    public func stepComputer() {
+        guard match.winner == nil, let seat = match.hand.nextSeat, seat != 0 else { return }
+        perform {
+            let view = try PlayerView(match: match, seat: seat)
+            guard let action = ComputerPlayer.decide(view) else { return }
+            try match.apply(action, seat: seat)
+        }
+    }
+
+    public func allows(_ action: PlayerAction) -> Bool {
+        guard isHumanTurn else { return false }
+        var copy = match
+        return (try? copy.apply(action, seat: 0)) != nil
+    }
+
+    public func nextHand() { perform { try match.startNextHand(deck: Self.deck()) } }
+    public func newGame() { perform { match = try Match(deck: Self.deck(), dealer: 3) } }
+
+    private func perform(_ action: () throws -> Void) {
+        do {
+            try action()
+            errorMessage = nil
+            persist()
+            revision += 1
+        } catch {
+            errorMessage = "That action could not be completed: \(error)"
+        }
+    }
+
+    public func persist() {
+        guard let saveURL else { return }
+        do { try MatchSave.write(match, to: saveURL) }
+        catch { errorMessage = "Could not save this game. Your current game is still open. \(error.localizedDescription)" }
+    }
+
+    public static func deck() -> [Card] {
+        Suit.allCases.flatMap { suit in Rank.allCases.map { Card(suit, $0) } }.shuffled()
+    }
+
+    public static func loadDefault() -> GameModel {
+        let directory = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("CatchFive", isDirectory: true)
+        let url = directory.appendingPathComponent("game.json")
+        // The generated deck is always a valid, unique 52-card deck.
+        let fresh = GameModel(match: try! Match(deck: deck(), dealer: 3), saveURL: url)
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            if FileManager.default.fileExists(atPath: url.path) {
+                return GameModel(match: try MatchSave.read(from: url), saveURL: url)
+            }
+        } catch {
+            fresh.errorMessage = "Your previous game could not be restored. A new game is ready. \(error.localizedDescription)"
+        }
+        return fresh
+    }
+}

--- a/Sources/CatchFiveUI/HandSummaryView.swift
+++ b/Sources/CatchFiveUI/HandSummaryView.swift
@@ -1,0 +1,27 @@
+import CatchFive
+import SwiftUI
+
+struct HandSummaryView: View {
+    let match: Match
+    var body: some View {
+        if let summary = match.history.last {
+            VStack(spacing: 8) {
+                Text("HAND POINTS  \(summary.result.points[0]) – \(summary.result.points[1])").font(.headline)
+                row("High", team: summary.result.highTeam)
+                row("Low", team: summary.result.lowTeam)
+                row("Jack", team: summary.result.jackTeam)
+                row("Five · 5 points", team: summary.result.fiveTeam)
+                row("Game · \(summary.result.gameValues[0])–\(summary.result.gameValues[1])", team: summary.result.gameTeam)
+                Text("\(["You", "West", "Partner", "East"][summary.bidder]) bid \(summary.isNineAndOut ? "9 and out" : String(summary.bid))")
+                    .font(.caption).opacity(0.6)
+            }.padding(16).background(.white.opacity(0.07), in: RoundedRectangle(cornerRadius: 16))
+        }
+    }
+    private func row(_ name: String, team: Int?) -> some View {
+        HStack {
+            Text(name)
+            Spacer()
+            Text(team.map { $0 == 0 ? "Your team" : "West + East" } ?? "Out of play")
+        }.font(.caption)
+    }
+}

--- a/Sources/CatchFiveUI/TableView.swift
+++ b/Sources/CatchFiveUI/TableView.swift
@@ -1,0 +1,172 @@
+import CatchFive
+import SwiftUI
+
+public struct TableView: View {
+    @StateObject private var model: GameModel
+    @Environment(\.scenePhase) private var scenePhase
+    @State private var confirmNewGame = false
+
+    public init(model: GameModel) { _model = StateObject(wrappedValue: model) }
+
+    public var body: some View {
+        ScrollView {
+            VStack(spacing: 12) {
+                header
+                scores
+                HStack {
+                    opponent(1, name: "West")
+                    Spacer()
+                    opponent(2, name: "Partner")
+                    Spacer()
+                    opponent(3, name: "East")
+                }
+                Text(status).font(.subheadline).multilineTextAlignment(.center).frame(minHeight: 40)
+                if model.match.hand.phase == .playing || model.match.hand.phase == .finished { trick }
+                if !model.humanCards.isEmpty { hand }
+                controls
+                Button("Start a new game") { confirmNewGame = true }
+                    .font(.footnote).tint(.ivory.opacity(0.65))
+            }
+            .padding(20).frame(maxWidth: 640)
+            .frame(maxWidth: .infinity)
+        }
+        .foregroundStyle(.ivory)
+        .background(LinearGradient(colors: [.felt, .black], startPoint: .topLeading, endPoint: .bottomTrailing).ignoresSafeArea())
+        .preferredColorScheme(.dark)
+        .task(id: model.revision) {
+            guard !model.isHumanTurn, model.match.hand.nextSeat != nil, model.match.winner == nil else { return }
+            try? await Task.sleep(for: .milliseconds(model.match.hand.currentTrick.isEmpty ? 1200 : 700))
+            guard !Task.isCancelled else { return }
+            model.stepComputer()
+        }
+        .onChange(of: scenePhase) { _, phase in if phase != .active { model.persist() } }
+        .alert("Game notice", isPresented: Binding(get: { model.errorMessage != nil }, set: { if !$0 { model.errorMessage = nil } })) {
+            Button("OK") { model.errorMessage = nil }
+        } message: { Text(model.errorMessage ?? "") }
+        .confirmationDialog("Start over? This replaces your saved game.", isPresented: $confirmNewGame) {
+            Button("Start new game", role: .destructive) { model.newGame() }
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("CATCH 5").font(.system(size: 34, weight: .bold, design: .serif))
+                Text("PARTNERSHIP PITCH · FIRST TO 25").font(.system(size: 9, weight: .medium, design: .monospaced)).tracking(1)
+            }
+            Spacer()
+            Text("HAND \(model.match.handNumber)").font(.caption.monospaced())
+        }
+    }
+
+    private var scores: some View {
+        HStack {
+            score("YOU + PARTNER", value: model.match.scores[0])
+            Spacer()
+            Text(model.match.hand.trump.map { "\($0.glyph)\nTRUMP" } ?? "—\nTRUMP")
+                .font(.caption.monospaced()).multilineTextAlignment(.center).foregroundStyle(.gold)
+            Spacer()
+            score("WEST + EAST", value: model.match.scores[1])
+        }.padding(16).background(.white.opacity(0.06), in: RoundedRectangle(cornerRadius: 16))
+    }
+
+    private func score(_ title: String, value: Int) -> some View {
+        VStack(spacing: 4) {
+            Text(title).font(.system(size: 9, design: .monospaced))
+            Text(value, format: .number).font(.system(size: 32, weight: .semibold, design: .serif))
+        }
+    }
+
+    private func opponent(_ seat: Int, name: String) -> some View {
+        VStack(spacing: 6) {
+            Text(name).font(.subheadline.weight(.semibold))
+            Text("\(model.match.hand.hands[seat].count) cards").font(.caption2).opacity(0.65)
+            if model.match.hand.auction.dealer == seat { Text("DEALER").font(.system(size: 8, design: .monospaced)).foregroundStyle(.gold) }
+        }.padding(12)
+            .background(model.match.hand.nextSeat == seat ? .white.opacity(0.14) : .white.opacity(0.04), in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    private var status: String {
+        if let winner = model.match.winner { return winner == 0 ? "Your team wins!" : "West + East win" }
+        switch model.match.hand.phase {
+        case .bidding:
+            let bid = model.match.hand.auction.isNineAndOut ? "9 and out" : model.match.hand.auction.highestBid.map(String.init) ?? "none"
+            return "High bid: \(bid)\n\(model.isHumanTurn ? "Your bid" : "Bidding…")"
+        case .choosingTrump: return model.isHumanTurn ? "Choose trump" : "Choosing trump…"
+        case .playing: return model.isHumanTurn ? "Your turn\nTap a legal card" : "Computer’s turn"
+        case .finished: return "Hand complete"
+        }
+    }
+
+    private var trick: some View {
+        let last = model.match.hand.completedTricks.last
+        let showingLast = model.match.hand.currentTrick.isEmpty && last != nil
+        let plays = showingLast ? last?.plays ?? [] : model.match.hand.currentTrick
+        let names = ["You", "West", "Partner", "East"]
+        return VStack(spacing: 12) {
+            Text(showingLast ? "LAST TRICK" : "ON THE TABLE")
+                .font(.caption2.monospaced()).tracking(2).opacity(0.6)
+            if showingLast, let winner = last?.winner {
+                let leads = model.match.hand.phase == .playing ? " and lead\(winner == 0 ? "" : "s") next" : ""
+                Text("\(names[winner]) took it\(leads)")
+                    .font(.footnote).foregroundStyle(.gold)
+            }
+            HStack(spacing: 12) {
+                ForEach(plays, id: \.seat) { play in
+                    VStack(spacing: 8) {
+                        CardView(card: play.card)
+                        Text(["You", "West", "Partner", "East"][play.seat]).font(.caption2)
+                    }
+                }
+                if plays.isEmpty { Text("Waiting for the first card").font(.footnote).opacity(0.45).frame(height: 96) }
+            }.frame(minHeight: 96)
+        }.frame(maxWidth: .infinity).padding(.vertical, 20)
+            .background(.white.opacity(0.025), in: RoundedRectangle(cornerRadius: 24))
+            .overlay(RoundedRectangle(cornerRadius: 24).stroke(.white.opacity(0.08)))
+    }
+
+    @ViewBuilder private var controls: some View {
+        if model.match.hand.phase == .finished {
+            HandSummaryView(match: model.match)
+            Button(model.match.winner == nil ? "Deal next hand" : "Play again") {
+                if model.match.winner == nil { model.nextHand() } else { model.newGame() }
+            }.buttonStyle(.borderedProminent).tint(.gold).foregroundStyle(.black)
+        } else if model.isHumanTurn && model.match.hand.phase == .bidding {
+            VStack(spacing: 12) {
+                Text("How many points can your team take?").font(.footnote)
+                LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 4), spacing: 8) {
+                    ForEach(2...9, id: \.self) { bid in actionButton(String(bid), action: .bid(bid)) }
+                }
+                HStack { actionButton("Pass", action: .bid(nil)); actionButton("9 and out", action: .nineAndOut) }
+                Text("9 and out: take all nine or lose the game.").font(.caption2).opacity(0.6)
+            }
+        } else if model.isHumanTurn && model.match.hand.phase == .choosingTrump {
+            HStack { ForEach(Suit.allCases, id: \.self) { suit in actionButton(suit.glyph, action: .chooseTrump(suit)) } }
+        }
+    }
+
+    private func actionButton(_ label: String, action: PlayerAction) -> some View {
+        Button(label) { model.send(action) }.buttonStyle(.bordered).tint(.gold)
+            .disabled(!model.allows(action)).frame(minHeight: 44)
+    }
+
+    private var hand: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("YOUR HAND").font(.caption.monospaced()).tracking(1)
+                Spacer()
+                if model.match.hand.auction.dealer == 0 { Text("DEALER").font(.caption2.monospaced()).foregroundStyle(.gold) }
+            }
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(model.humanCards, id: \.self) { card in
+                        Button { model.send(.play(card)) } label: { CardView(card: card) }
+                            .buttonStyle(.plain)
+                            .disabled(!model.allows(.play(card)))
+                            .opacity(model.match.hand.phase == .playing && !model.allows(.play(card)) ? 0.5 : 1)
+                    }
+                }.padding(.bottom, 8)
+            }
+        }
+    }
+}

--- a/Tests/CatchFiveTests/BiddingTests.swift
+++ b/Tests/CatchFiveTests/BiddingTests.swift
@@ -47,3 +47,15 @@ import Testing
     #expect(auction.nextSeat == nil)
     #expect(throws: RuleError.invalidSeat) { try Auction(dealer: 4) }
 }
+
+@Test func nineAndOutOvercallsNineAndDealerCanMatch() throws {
+    var auction = try Auction(dealer: 3)
+    try auction.act(seat: 0, bid: 9)
+    try auction.act(seat: 1, bid: 9, nineAndOut: true)
+    #expect(throws: RuleError.invalidBid) { try auction.act(seat: 2, bid: 9, nineAndOut: true) }
+    try auction.act(seat: 2, bid: nil)
+    #expect(throws: RuleError.invalidBid) { try auction.act(seat: 3, bid: 9) }
+    try auction.act(seat: 3, bid: 9, nineAndOut: true)
+    #expect(auction.winner == 3)
+    #expect(auction.isNineAndOut)
+}

--- a/Tests/CatchFiveTests/BiddingTests.swift
+++ b/Tests/CatchFiveTests/BiddingTests.swift
@@ -1,0 +1,49 @@
+import Testing
+@testable import CatchFive
+
+@Test func dealerCanMatchPartnerOrOpponent() throws {
+    for openingSeat in [0, 1, 2] {
+        var auction = try Auction(dealer: 3)
+        for seat in 0..<3 { try auction.act(seat: seat, bid: seat == openingSeat ? 4 : nil) }
+        try auction.act(seat: 3, bid: 4)
+        #expect(auction.winner == 3)
+        #expect(auction.highestBid == 4)
+        #expect(auction.nextSeat == nil)
+    }
+}
+
+@Test func nonDealerMustRaiseAndInvalidActionDoesNotConsumeTurn() throws {
+    var auction = try Auction(dealer: 3)
+    try auction.act(seat: 0, bid: 4)
+    #expect(throws: RuleError.invalidBid) { try auction.act(seat: 1, bid: 4) }
+    #expect(auction.nextSeat == 1)
+    try auction.act(seat: 1, bid: 5)
+    #expect(auction.winner == 1)
+}
+
+@Test func dealerMustTakeTwoAfterPasses() throws {
+    var auction = try Auction(dealer: 3)
+    for seat in 0..<3 { try auction.act(seat: seat, bid: nil) }
+    #expect(throws: RuleError.invalidBid) { try auction.act(seat: 3, bid: nil) }
+    try auction.act(seat: 3, bid: 2)
+    #expect(auction.winner == 3)
+    #expect(auction.highestBid == 2)
+    #expect(throws: RuleError.auctionComplete) { try auction.act(seat: 0, bid: 3) }
+}
+
+@Test func bidRangeAndTurnOrder() throws {
+    var auction = try Auction(dealer: 1)
+    #expect(auction.nextSeat == 2)
+    #expect(throws: RuleError.outOfTurn) { try auction.act(seat: 0, bid: 2) }
+    for bid in [-1, 0, 1, 10] {
+        #expect(throws: RuleError.invalidBid) { try auction.act(seat: 2, bid: bid) }
+    }
+    try auction.act(seat: 2, bid: 9)
+    try auction.act(seat: 3, bid: nil)
+    try auction.act(seat: 0, bid: nil)
+    try auction.act(seat: 1, bid: nil)
+    #expect(auction.winner == 2)
+    #expect(auction.highestBid == 9)
+    #expect(auction.nextSeat == nil)
+    #expect(throws: RuleError.invalidSeat) { try Auction(dealer: 4) }
+}

--- a/Tests/CatchFiveTests/ComputerPlayerTests.swift
+++ b/Tests/CatchFiveTests/ComputerPlayerTests.swift
@@ -1,0 +1,102 @@
+import Testing
+@testable import CatchFive
+
+private func view(cards: [Card], phase: HandPhase = .playing, seat: Int = 0,
+                  dealer: Int = 3, highestBid: Int? = nil, bidder: Int? = nil,
+                  trick: [Play] = []) -> PlayerView {
+    PlayerView(seat: seat, cards: cards, phase: phase, nextSeat: seat,
+               dealer: dealer, highestBid: highestBid, bidder: bidder,
+               trump: .hearts, trick: trick)
+}
+
+@Test func computerPassesWeakHandButDealerTakesForcedTwo() {
+    let cards = [Card(.clubs, .two), Card(.spades, .three)]
+    #expect(ComputerPlayer.decide(view(cards: cards, phase: .bidding)) == .bid(nil))
+    #expect(ComputerPlayer.decide(view(cards: cards, phase: .bidding, dealer: 0)) == .bid(2))
+}
+
+@Test func computerRaisesWithStrongSuitAndChoosesIt() {
+    let cards = [Card(.spades, .ace), Card(.spades, .king), Card(.spades, .jack),
+                 Card(.spades, .five), Card(.clubs, .two), Card(.diamonds, .three)]
+    #expect(ComputerPlayer.decide(view(cards: cards, phase: .bidding, highestBid: 3, bidder: 1)) == .bid(4))
+    #expect(ComputerPlayer.decide(view(cards: cards, phase: .choosingTrump)) == .chooseTrump(.spades))
+    #expect(ComputerPlayer.decide(view(cards: cards, phase: .bidding, highestBid: 3, bidder: 2)) == .bid(nil))
+    #expect(ComputerPlayer.decide(view(cards: cards, phase: .bidding, dealer: 0, highestBid: 3, bidder: 1)) == .bid(3))
+}
+
+@Test func computerFollowsSuitInsteadOfTrumping() {
+    let cards = [Card(.hearts, .ace), Card(.clubs, .two)]
+    let trick = [Play(seat: 3, card: Card(.clubs, .king))]
+    #expect(ComputerPlayer.decide(view(cards: cards, trick: trick)) == .play(Card(.clubs, .two)))
+}
+
+@Test func computerUsesLowestWinningCardAgainstOpponent() {
+    let cards = [Card(.hearts, .ace), Card(.hearts, .queen), Card(.hearts, .two)]
+    let trick = [Play(seat: 3, card: Card(.hearts, .jack))]
+    #expect(ComputerPlayer.decide(view(cards: cards, trick: trick)) == .play(Card(.hearts, .queen)))
+}
+
+@Test func computerFeedsFiveToPartnerWhenLastToPlay() {
+    let cards = [Card(.hearts, .five), Card(.hearts, .two)]
+    let trick = [Play(seat: 1, card: Card(.hearts, .king)),
+                 Play(seat: 2, card: Card(.hearts, .ace)),
+                 Play(seat: 3, card: Card(.hearts, .three))]
+    #expect(ComputerPlayer.decide(view(cards: cards, trick: trick)) == .play(Card(.hearts, .five)))
+}
+
+@Test func computerPreservesFiveWhenItCannotWin() {
+    let cards = [Card(.hearts, .five), Card(.hearts, .three)]
+    let trick = [Play(seat: 3, card: Card(.hearts, .ace))]
+    #expect(ComputerPlayer.decide(view(cards: cards, trick: trick)) == .play(Card(.hearts, .three)))
+}
+
+@Test func computerDoesNotActOutsideItsTurn() throws {
+    let deck = Suit.allCases.flatMap { suit in Rank.allCases.map { Card(suit, $0) } }
+    let match = try Match(deck: deck, dealer: 3)
+    #expect(ComputerPlayer.decide(try PlayerView(match: match, seat: 1)) == nil)
+    #expect(throws: RuleError.invalidSeat) { try PlayerView(match: match, seat: 4) }
+}
+
+@Test func changingHiddenCardsDoesNotChangeComputerDecision() throws {
+    var deck = Suit.allCases.flatMap { suit in Rank.allCases.map { Card(suit, $0) } }
+    let first = try Match(deck: deck, dealer: 3)
+    // Seat 0 gets positions 0...2 and 12...14. Swap an opponent card with stock.
+    deck.swapAt(3, 40)
+    let second = try Match(deck: deck, dealer: 3)
+    let a = try PlayerView(match: first, seat: 0)
+    let b = try PlayerView(match: second, seat: 0)
+    #expect(a.cards == b.cards)
+    #expect(ComputerPlayer.decide(a) == ComputerPlayer.decide(b))
+}
+
+private struct RepeatableRandom: RandomNumberGenerator {
+    var state: UInt64
+    mutating func next() -> UInt64 {
+        state = state &* 6364136223846793005 &+ 1442695040888963407
+        return state
+    }
+}
+
+@Test func computersCompleteShuffledMatchesThroughRealRules() throws {
+    let deck = Suit.allCases.flatMap { suit in Rank.allCases.map { Card(suit, $0) } }
+    for seed in 1...24 {
+        var random = RepeatableRandom(state: UInt64(seed))
+        var match = try Match(deck: deck.shuffled(using: &random), dealer: seed % 4)
+        for _ in 0..<10000 {
+            if match.winner != nil { break }
+            if match.hand.phase == .finished {
+                try match.startNextHand(deck: deck.shuffled(using: &random))
+                continue
+            }
+            let seat = try #require(match.hand.nextSeat)
+            let action = try #require(ComputerPlayer.decide(PlayerView(match: match, seat: seat)))
+            try match.apply(action, seat: seat)
+        }
+        let winner = try #require(match.winner)
+        #expect(match.scores[winner] >= 25)
+        #expect(match.history.count >= 3)
+        let restored = try MatchSave.decode(MatchSave.encode(match))
+        #expect(restored.winner == winner)
+        #expect(restored.scores == match.scores)
+    }
+}

--- a/Tests/CatchFiveTests/HandTests.swift
+++ b/Tests/CatchFiveTests/HandTests.swift
@@ -1,0 +1,122 @@
+import Testing
+@testable import CatchFive
+
+private let deck = Suit.allCases.flatMap { suit in Rank.allCases.map { Card(suit, $0) } }
+
+private func startHand(dealer: Int = 3, trump: Suit = .hearts, cards: [Card] = deck) throws -> Hand {
+    var hand = try Hand(deck: cards, dealer: dealer)
+    let bidder = (dealer + 1) % 4
+    try hand.bid(seat: bidder, amount: 2)
+    for offset in 1...3 { try hand.bid(seat: (bidder + offset) % 4, amount: nil) }
+    try hand.chooseTrump(seat: bidder, suit: trump)
+    return hand
+}
+
+private func allCards(_ hand: Hand) -> [Card] {
+    hand.hands.flatMap { $0 } + hand.stock + hand.discarded
+        + hand.captured.flatMap { $0 } + hand.currentTrick.map(\.card)
+}
+
+@Test func dealSixEachInTwoPacketsStartingLeftOfDealer() throws {
+    let hand = try Hand(deck: deck, dealer: 3)
+    #expect(hand.hands.map(\.count) == [6, 6, 6, 6])
+    #expect(hand.hands[0] == [Card(.clubs, .two), Card(.clubs, .three), Card(.clubs, .four),
+                            Card(.clubs, .ace), Card(.diamonds, .two), Card(.diamonds, .three)])
+    #expect(hand.stock.count == 28)
+    #expect(Set(allCards(hand)).count == 52)
+    #expect(hand.nextSeat == 0)
+}
+
+@Test func rejectInvalidDecks() {
+    #expect(throws: HandError.invalidDeck) { try Hand(deck: [], dealer: 0) }
+    #expect(throws: HandError.invalidDeck) { try Hand(deck: Array(repeating: deck[0], count: 52), dealer: 0) }
+}
+
+@Test func trumpSelectionRequiresFinishedAuctionAndWinningSeat() throws {
+    var hand = try Hand(deck: deck, dealer: 3)
+    #expect(throws: HandError.wrongPhase) { try hand.chooseTrump(seat: 0, suit: .clubs) }
+    #expect(throws: HandError.wrongPhase) { try hand.play(seat: 0, card: deck[0]) }
+    try hand.bid(seat: 0, amount: 4)
+    try hand.bid(seat: 1, amount: nil)
+    try hand.bid(seat: 2, amount: nil)
+    try hand.bid(seat: 3, amount: 4)
+    #expect(hand.phase == .choosingTrump)
+    #expect(hand.nextSeat == 3)
+    #expect(throws: HandError.notBidWinner) { try hand.chooseTrump(seat: 0, suit: .clubs) }
+    #expect(throws: HandError.wrongPhase) { try hand.bid(seat: 3, amount: 5) }
+    try hand.chooseTrump(seat: 3, suit: .clubs)
+    #expect(hand.nextSeat == 3)
+    #expect(hand.phase == .playing)
+}
+
+@Test func refillKeepsTrumpsAndDiscardsOnlyInitialNonTrumps() throws {
+    let original = try Hand(deck: deck, dealer: 3)
+    let hand = try startHand(trump: .clubs)
+    #expect(hand.hands.map(\.count) == [6, 6, 6, 6])
+    #expect(hand.discarded.count == 11)
+    #expect(hand.stock.count == 17)
+    #expect(hand.discarded.allSatisfy { $0.suit != .clubs })
+    for seat in 0..<4 {
+        #expect(original.hands[seat].filter { $0.suit == .clubs }.allSatisfy { hand.hands[seat].contains($0) })
+    }
+    #expect(allCards(hand).count == 52)
+    #expect(Set(allCards(hand)).count == 52)
+}
+
+@Test func illegalPlayLeavesStateUnchanged() throws {
+    var hand = try startHand()
+    let before = hand.hands
+    #expect(throws: RuleError.outOfTurn) { try hand.play(seat: 1, card: deck[0]) }
+    #expect(throws: HandError.cardNotHeld) { try hand.play(seat: 0, card: Card(.clubs, .two)) }
+    #expect(hand.hands == before)
+    #expect(hand.currentTrick.isEmpty)
+    #expect(hand.nextSeat == 0)
+    #expect(hand.legalMoves(seat: 1).isEmpty)
+    #expect(hand.legalMoves(seat: -1).isEmpty)
+}
+
+@Test func playMustFollowSuitAndWinningPlayerLeadsNext() throws {
+    // Construct a deck with all 13 hearts first so each player retains hearts after refill.
+    let ordered = deck.sorted { ($0.suit == .hearts ? 0 : 1) < ($1.suit == .hearts ? 0 : 1) }
+    var hand = try startHand(cards: ordered)
+    let lead = try #require(hand.hands[0].first { $0.suit == .hearts })
+    try hand.play(seat: 0, card: lead)
+    let offSuit = try #require(hand.hands[1].first { $0.suit != .hearts })
+    let before = hand.hands
+    #expect(throws: HandError.mustFollowSuit) { try hand.play(seat: 1, card: offSuit) }
+    #expect(hand.hands == before)
+    #expect(hand.nextSeat == 1)
+    for seat in 1...3 {
+        let card = try #require(hand.legalMoves(seat: seat).first)
+        try hand.play(seat: seat, card: card)
+    }
+    let trick = try #require(hand.completedTricks.first)
+    #expect(hand.nextSeat == trick.winner)
+    #expect(hand.currentTrick.isEmpty)
+    #expect(hand.captured[trick.winner % 2].count == 4)
+}
+
+@Test func completeHandsConserveCardsAndFinishAfterSixTricks() throws {
+    // 208 deterministic deck rotations, covering every dealer and trump suit.
+    for rotation in 0..<52 {
+        let cards = Array(deck[rotation...]) + Array(deck[..<rotation])
+        for dealer in 0..<4 {
+            var hand = try startHand(dealer: dealer, trump: Suit.allCases[(rotation + dealer) % 4], cards: cards)
+            for _ in 0..<24 {
+                let seat = try #require(hand.nextSeat)
+                let move = try #require(hand.legalMoves(seat: seat).first)
+                try hand.play(seat: seat, card: move)
+                #expect(allCards(hand).count == 52)
+                #expect(Set(allCards(hand)).count == 52)
+            }
+            #expect(hand.phase == .finished)
+            #expect(hand.nextSeat == nil)
+            #expect(hand.completedTricks.count == 6)
+            #expect(hand.hands.allSatisfy { $0.isEmpty })
+            #expect(hand.captured.flatMap { $0 }.count == 24)
+            let result = try #require(hand.result)
+            #expect((1...9).contains(result.points.reduce(0, +)))
+            #expect(throws: HandError.wrongPhase) { try hand.play(seat: 0, card: cards[0]) }
+        }
+    }
+}

--- a/Tests/CatchFiveTests/MatchTests.swift
+++ b/Tests/CatchFiveTests/MatchTests.swift
@@ -102,3 +102,26 @@ private func playCards(_ count: Int, in match: inout Match) throws {
     #expect(match.scores == [26, 16])
     #expect(match.history.count == 5)
 }
+
+@Test func specialBidFlowsThroughMatchAndSavedGame() throws {
+    var match = try Match(deck: matchDeck(1), dealer: 3)
+    try match.bidNineAndOut(seat: 0)
+    for seat in 1...3 { try match.bid(seat: seat, amount: nil) }
+    match = try MatchSave.decode(MatchSave.encode(match))
+    #expect(match.hand.auction.isNineAndOut)
+    try match.chooseTrump(seat: 0, suit: .diamonds)
+    try playCards(24, in: &match)
+    #expect(match.winner == 1)
+    #expect(match.history.first?.isNineAndOut == true)
+    #expect(try MatchSave.decode(MatchSave.encode(match)).winner == 1)
+}
+
+@Test func negativeTeamCannotDeclareNineAndOut() throws {
+    var match = try Match(deck: matchDeck(1), dealer: 3)
+    try prepare(&match, bid: 4)
+    try playCards(24, in: &match)
+    try match.startNextHand(deck: matchDeck(2))
+    try match.bid(seat: 1, amount: nil)
+    #expect(throws: RuleError.forbiddenNineAndOut) { try match.bidNineAndOut(seat: 2) }
+    #expect(match.hand.nextSeat == 2)
+}

--- a/Tests/CatchFiveTests/MatchTests.swift
+++ b/Tests/CatchFiveTests/MatchTests.swift
@@ -1,0 +1,104 @@
+import Testing
+@testable import CatchFive
+
+private func matchDeck(_ number: Int) -> [Card] {
+    let deck = Suit.allCases.flatMap { suit in Rank.allCases.map { Card(suit, $0) } }
+    let rotation = (number * 7) % 52
+    return Array(deck[rotation...]) + Array(deck[..<rotation])
+}
+
+private func prepare(_ match: inout Match, bid: Int = 2) throws {
+    let bidder = (match.hand.auction.dealer + 1) % 4
+    try match.bid(seat: bidder, amount: bid)
+    for offset in 1...3 { try match.bid(seat: (bidder + offset) % 4, amount: nil) }
+    try match.chooseTrump(seat: bidder, suit: Suit.allCases[match.handNumber % 4])
+}
+
+private func playCards(_ count: Int, in match: inout Match) throws {
+    for _ in 0..<count {
+        let seat = try #require(match.hand.nextSeat)
+        let card = try #require(match.hand.legalMoves(seat: seat).first)
+        try match.play(seat: seat, card: card)
+    }
+}
+
+@Test func matchRejectsPrematureRedeal() throws {
+    var match = try Match(deck: matchDeck(1), dealer: 3)
+    let cards = match.hand.hands
+    #expect(throws: MatchError.handInProgress) { try match.startNextHand(deck: matchDeck(2)) }
+    #expect(match.hand.hands == cards)
+    #expect(match.handNumber == 1)
+    #expect(match.scores == [0, 0])
+}
+
+@Test func matchScoresOnlyAfterLastCardAndOnlyOnce() throws {
+    var match = try Match(deck: matchDeck(1), dealer: 3)
+    try prepare(&match)
+    try playCards(23, in: &match)
+    #expect(match.scores == [0, 0])
+    #expect(match.history.isEmpty)
+    try playCards(1, in: &match)
+    #expect(match.scores == [2, 7])
+    let summary = try #require(match.history.first)
+    #expect(summary.number == 1)
+    #expect(summary.dealer == 3)
+    #expect(summary.bidder == 0)
+    #expect(summary.bid == 2)
+    #expect(summary.result.gameValues == [24, 16])
+    #expect(summary.scores == [2, 7])
+    #expect(throws: HandError.wrongPhase) { try match.play(seat: 0, card: Card(.clubs, .two)) }
+    #expect(match.history.count == 1)
+    #expect(match.scores == [2, 7])
+}
+
+@Test func nextHandRotatesDealerAndRetainsScores() throws {
+    var match = try Match(deck: matchDeck(1), dealer: 3)
+    try prepare(&match)
+    try playCards(24, in: &match)
+    #expect(throws: HandError.invalidDeck) { try match.startNextHand(deck: []) }
+    #expect(match.handNumber == 1)
+    #expect(match.hand.phase == .finished)
+    try match.startNextHand(deck: matchDeck(2))
+    #expect(match.handNumber == 2)
+    #expect(match.hand.auction.dealer == 0)
+    #expect(match.hand.nextSeat == 1)
+    #expect(match.hand.phase == .bidding)
+    #expect(match.scores == [2, 7])
+    #expect(match.history.count == 1)
+}
+
+@Test func matchRejectsInvalidActionsWithoutChangingState() throws {
+    var match = try Match(deck: matchDeck(1), dealer: 3)
+    #expect(throws: RuleError.outOfTurn) { try match.bid(seat: 2, amount: 2) }
+    #expect(throws: HandError.wrongPhase) { try match.chooseTrump(seat: 0, suit: .clubs) }
+    #expect(match.hand.nextSeat == 0)
+    #expect(match.hand.auction.highestBid == nil)
+    #expect(match.history.isEmpty)
+}
+
+@Test func failedBidMakesNegativeMatchScore() throws {
+    var match = try Match(deck: matchDeck(1), dealer: 3)
+    try prepare(&match, bid: 4)
+    try playCards(24, in: &match)
+    #expect(match.scores == [-4, 7])
+    #expect(match.winner == nil)
+}
+
+@Test func completeMatchConnectsBiddingTricksScoringAndVictory() throws {
+    var match = try Match(deck: matchDeck(1), dealer: 3)
+    let expectedScores = [[2, 7], [10, 5], [12, 12], [19, 14], [26, 16]]
+    for number in 1...5 {
+        if number > 1 { try match.startNextHand(deck: matchDeck(number)) }
+        try prepare(&match)
+        try playCards(24, in: &match)
+        #expect(match.scores == expectedScores[number - 1])
+        #expect(match.history.count == number)
+        #expect(match.winner == (number == 5 ? 0 : nil))
+    }
+    #expect(throws: MatchError.matchFinished) { try match.startNextHand(deck: matchDeck(6)) }
+    #expect(throws: MatchError.matchFinished) { try match.bid(seat: 0, amount: 2) }
+    #expect(throws: MatchError.matchFinished) { try match.chooseTrump(seat: 0, suit: .clubs) }
+    #expect(throws: MatchError.matchFinished) { try match.play(seat: 0, card: Card(.clubs, .ace)) }
+    #expect(match.scores == [26, 16])
+    #expect(match.history.count == 5)
+}

--- a/Tests/CatchFiveTests/SaveTests.swift
+++ b/Tests/CatchFiveTests/SaveTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import Testing
+@testable import CatchFive
+
+private let saveDeck = Suit.allCases.flatMap { suit in Rank.allCases.map { Card(suit, $0) } }
+
+private func readyMatch() throws -> Match {
+    var match = try Match(deck: saveDeck, dealer: 3)
+    try match.bid(seat: 0, amount: 2)
+    for seat in 1...3 { try match.bid(seat: seat, amount: nil) }
+    try match.chooseTrump(seat: 0, suit: .hearts)
+    return match
+}
+
+private func advance(_ match: inout Match, count: Int) throws {
+    for _ in 0..<count {
+        let seat = try #require(match.hand.nextSeat)
+        let card = try #require(match.hand.legalMoves(seat: seat).first)
+        try match.play(seat: seat, card: card)
+    }
+}
+
+@Test func saveRestoresEveryPhaseAndContinuesIdentically() throws {
+    var bidding = try Match(deck: saveDeck, dealer: 3)
+    try bidding.bid(seat: 0, amount: 4)
+    var resumedBid = try MatchSave.decode(MatchSave.encode(bidding))
+    #expect(resumedBid.hand.auction.highestBid == 4)
+    #expect(resumedBid.hand.nextSeat == 1)
+    for seat in 1...3 { try resumedBid.bid(seat: seat, amount: nil) }
+    let choosing = try MatchSave.decode(MatchSave.encode(resumedBid))
+    #expect(choosing.hand.phase == .choosingTrump)
+    #expect(choosing.hand.nextSeat == 0)
+
+    for played in [0, 1, 3, 4, 23, 24] {
+        var original = try readyMatch()
+        try advance(&original, count: played)
+        var restored = try MatchSave.decode(MatchSave.encode(original))
+        #expect(restored.hand.hands == original.hand.hands)
+        #expect(restored.hand.currentTrick == original.hand.currentTrick)
+        #expect(restored.hand.nextSeat == original.hand.nextSeat)
+        #expect(restored.hand.stock == original.hand.stock)
+        #expect(restored.hand.discarded == original.hand.discarded)
+        try advance(&original, count: 24 - played)
+        try advance(&restored, count: 24 - played)
+        #expect(restored.scores == original.scores)
+        #expect(restored.hand.result == original.hand.result)
+        #expect(restored.history.count == 1)
+    }
+}
+
+@Test func saveRestoresHistoryAndNextDealer() throws {
+    var match = try readyMatch()
+    try advance(&match, count: 24)
+    try match.startNextHand(deck: saveDeck)
+    let restored = try MatchSave.decode(MatchSave.encode(match))
+    #expect(restored.handNumber == 2)
+    #expect(restored.hand.auction.dealer == 0)
+    #expect(restored.history.count == 1)
+    #expect(restored.scores == match.scores)
+}
+
+@Test func saveRoundTripOnDiskReplacesPreviousSave() throws {
+    let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let url = directory.appendingPathComponent("match.json")
+    var match = try readyMatch()
+    try MatchSave.write(match, to: url)
+    try advance(&match, count: 3)
+    try MatchSave.write(match, to: url)
+    let restored = try MatchSave.read(from: url)
+    #expect(restored.hand.currentTrick.count == 3)
+    #expect(restored.hand.nextSeat == 3)
+    #expect(restored.hand.hands == match.hand.hands)
+}
+
+@Test func rejectsBrokenOrUnsupportedSave() throws {
+    #expect(throws: SaveError.invalidData) { try MatchSave.decode(Data("broken".utf8)) }
+    let match = try readyMatch()
+    let data = try MatchSave.encode(match)
+    var object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    object["version"] = 999
+    let future = try JSONSerialization.data(withJSONObject: object)
+    #expect(throws: SaveError.unsupportedVersion(999)) { try MatchSave.decode(future) }
+}
+
+@Test func diskFailuresAreReported() throws {
+    let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        .appendingPathComponent("missing/match.json")
+    let match = try readyMatch()
+    #expect(throws: (any Error).self) { try MatchSave.write(match, to: url) }
+    #expect(throws: (any Error).self) { try MatchSave.read(from: url) }
+}
+
+@Test func replayRejectsIllegalActionsAndInvalidInitialDeck() throws {
+    let match = try readyMatch()
+    var object = try #require(JSONSerialization.jsonObject(with: MatchSave.encode(match)) as? [String: Any])
+    let illegal = try JSONEncoder().encode([SavedAction.bid(seat: 3, amount: 2)])
+    object["actions"] = try JSONSerialization.jsonObject(with: illegal)
+    let badAction = try JSONSerialization.data(withJSONObject: object)
+    #expect(throws: SaveError.invalidData) { try MatchSave.decode(badAction) }
+    object["initialDeck"] = []
+    let badDeck = try JSONSerialization.data(withJSONObject: object)
+    #expect(throws: SaveError.invalidData) { try MatchSave.decode(badDeck) }
+}
+
+@Test func rejectedActionsNeverEnterSaveAndResavingDoesNotDuplicateActions() throws {
+    var match = try readyMatch()
+    let before = try MatchSave.encode(match)
+    #expect(throws: RuleError.outOfTurn) { try match.play(seat: 1, card: Card(.clubs, .two)) }
+    #expect(try MatchSave.encode(match) == before)
+    var resumed = try MatchSave.decode(before)
+    try advance(&resumed, count: 3)
+    let saved = try MatchSave.encode(resumed)
+    let restored = try MatchSave.decode(saved)
+    #expect(try MatchSave.encode(restored) == saved)
+    #expect(restored.hand.currentTrick.count == 3)
+}

--- a/Tests/CatchFiveTests/ScoringTests.swift
+++ b/Tests/CatchFiveTests/ScoringTests.swift
@@ -1,0 +1,97 @@
+import Testing
+@testable import CatchFive
+
+@Test func relativeHighAndLowBelongToCapturingTeams() throws {
+    let result = try scoreHand(captured: [
+        [Card(.hearts, .king), Card(.hearts, .jack), Card(.hearts, .five)],
+        [Card(.hearts, .four), Card(.clubs, .ten)]
+    ], trump: .hearts, bidder: 0)
+    #expect(result.highTeam == 0)
+    #expect(result.lowTeam == 1)
+    #expect(result.jackTeam == 0)
+    #expect(result.fiveTeam == 0)
+    #expect(result.gameValues == [4, 10])
+    #expect(result.gameTeam == 1)
+    #expect(result.points == [7, 2])
+}
+
+@Test func missingJackAndFiveDoNotScoreAndGameTieGoesToBidder() throws {
+    for bidder in [0, 1] {
+        let result = try scoreHand(captured: [[Card(.clubs, .king)], [Card(.diamonds, .king)]],
+                                   trump: .clubs, bidder: bidder)
+        #expect(result.highTeam == 0)
+        #expect(result.lowTeam == 0)
+        #expect(result.jackTeam == nil)
+        #expect(result.fiveTeam == nil)
+        #expect(result.gameValues == [3, 3])
+        #expect(result.gameTeam == bidder)
+        #expect(result.points == (bidder == 0 ? [3, 0] : [2, 1]))
+    }
+}
+
+@Test func offSuitScoringCardsOnlyCountTowardGame() throws {
+    let result = try scoreHand(captured: [[Card(.spades, .jack), Card(.spades, .five)],
+                                        [Card(.diamonds, .ace), Card(.clubs, .queen)]],
+                               trump: .hearts, bidder: 0)
+    #expect(result.points == [0, 1])
+    #expect(result.gameValues == [1, 6])
+    #expect(result.highTeam == nil)
+    #expect(result.lowTeam == nil)
+}
+
+@Test func invalidCapturedCardsAreRejected() {
+    #expect(throws: RuleError.invalidScoring) { try scoreHand(captured: [], trump: .clubs, bidder: 0) }
+    #expect(throws: RuleError.invalidScoring) {
+        try scoreHand(captured: [[Card(.clubs, .ace)], [Card(.clubs, .ace)]], trump: .clubs, bidder: 0)
+    }
+    #expect(throws: RuleError.invalidScoring) { try scoreHand(captured: [[], []], trump: .clubs, bidder: 2) }
+}
+
+@Test func successfulBidScoresAllPointsAndSetLosesBidAmount() throws {
+    #expect(try settle(scores: [0, 0], points: [7, 2], bidder: 0, bid: .points(4)).scores == [7, 2])
+    #expect(try settle(scores: [1, 0], points: [3, 6], bidder: 0, bid: .points(4)).scores == [-3, 6])
+    #expect(try settle(scores: [0, -2], points: [1, 8], bidder: 1, bid: .points(5)).scores == [1, 6])
+}
+
+@Test func twentyFiveAndSimultaneousFinish() throws {
+    #expect(try settle(scores: [24, 24], points: [2, 7], bidder: 0, bid: .points(2)).winner == 0)
+    #expect(try settle(scores: [24, 24], points: [7, 2], bidder: 1, bid: .points(2)).winner == 1)
+    #expect(try settle(scores: [20, 24], points: [3, 6], bidder: 0, bid: .points(4)).winner == 1)
+    #expect(try settle(scores: [0, 0], points: [3, 6], bidder: 0, bid: .points(3)).winner == nil)
+    #expect(try settle(scores: [23, 0], points: [2, 7], bidder: 0, bid: .points(2)).winner == 0)
+}
+
+@Test func nineAndOutWinsOrLosesImmediately() throws {
+    for bidder in [0, 1] {
+        var all = [0, 0]
+        all[bidder] = 9
+        #expect(try settle(scores: [0, 0], points: all, bidder: bidder, bid: .nineAndOut).winner == bidder)
+        for collected in 0..<9 {
+            var points = [0, 0]
+            points[bidder] = collected
+            #expect(try settle(scores: [24, 24], points: points, bidder: bidder,
+                               bid: .nineAndOut).winner == 1 - bidder)
+        }
+    }
+    #expect(throws: RuleError.forbiddenNineAndOut) {
+        try settle(scores: [-1, 0], points: [9, 0], bidder: 0, bid: .nineAndOut)
+    }
+    #expect(try settle(scores: [0, 0], points: [9, 0], bidder: 0, bid: .points(9)).winner == nil)
+}
+
+@Test func invalidSettlementRejected() {
+    for points in [[10, 0], [5, 5], [-1, 1], [1]] {
+        #expect(throws: RuleError.invalidScoring) {
+            try settle(scores: [0, 0], points: points, bidder: 0, bid: .points(2))
+        }
+    }
+    #expect(throws: RuleError.invalidScoring) {
+        try settle(scores: [], points: [2, 7], bidder: 0, bid: .points(2))
+    }
+    #expect(throws: RuleError.invalidScoring) {
+        try settle(scores: [0, 0], points: [2, 7], bidder: 2, bid: .points(2))
+    }
+    #expect(throws: RuleError.invalidBid) {
+        try settle(scores: [0, 0], points: [2, 7], bidder: 0, bid: .points(1))
+    }
+}

--- a/Tests/CatchFiveTests/TrickTests.swift
+++ b/Tests/CatchFiveTests/TrickTests.swift
@@ -1,0 +1,37 @@
+import Testing
+@testable import CatchFive
+
+@Test func mustFollowSuitEvenWithTrump() {
+    let club = Card(.clubs, .two)
+    let hand = [club, Card(.hearts, .ace)]
+    #expect(legalCards(in: hand, led: .clubs) == [club])
+    #expect(legalCards(in: hand, led: .spades) == hand)
+    #expect(legalCards(in: hand, led: nil) == hand)
+}
+
+@Test func trumpBeatsLedAce() throws {
+    let plays = [Play(seat: 2, card: Card(.clubs, .ace)),
+                 Play(seat: 3, card: Card(.hearts, .two)),
+                 Play(seat: 0, card: Card(.clubs, .king)),
+                 Play(seat: 1, card: Card(.spades, .ace))]
+    #expect(try trickWinner(plays, trump: .hearts) == 3)
+    #expect(try trickWinner(plays, trump: .diamonds) == 2)
+}
+
+@Test func highestTrumpWins() throws {
+    let plays = [Play(seat: 0, card: Card(.clubs, .ace)),
+                 Play(seat: 1, card: Card(.hearts, .two)),
+                 Play(seat: 2, card: Card(.hearts, .king)),
+                 Play(seat: 3, card: Card(.hearts, .five))]
+    #expect(try trickWinner(plays, trump: .hearts) == 2)
+}
+
+@Test func malformedTricksAreRejected() {
+    #expect(throws: RuleError.invalidTrick) { try trickWinner([], trump: .clubs) }
+    let duplicate = Array(repeating: Play(seat: 0, card: Card(.clubs, .ace)), count: 4)
+    #expect(throws: RuleError.invalidTrick) { try trickWinner(duplicate, trump: .clubs) }
+}
+
+@Test func cardValuesForGame() {
+    #expect(Rank.allCases.map(\.gameValue) == [0, 0, 0, 0, 0, 0, 0, 0, 10, 1, 2, 3, 4])
+}

--- a/Tests/CatchFiveUITests/GameModelTests.swift
+++ b/Tests/CatchFiveUITests/GameModelTests.swift
@@ -1,0 +1,35 @@
+import CatchFive
+import CatchFiveUI
+import Foundation
+import Testing
+
+@MainActor @Test func humanActionAdvancesComputersAndStopsForHuman() throws {
+    let deck = Suit.allCases.flatMap { suit in Rank.allCases.map { Card(suit, $0) } }
+    let model = GameModel(match: try Match(deck: deck, dealer: 3))
+    model.send(.bid(9))
+    #expect(model.match.hand.nextSeat == 1)
+    for _ in 0..<3 { model.stepComputer() }
+    #expect(model.isHumanTurn)
+    #expect(model.match.hand.phase == .choosingTrump)
+    model.stepComputer()
+    #expect(model.match.hand.phase == .choosingTrump)
+    model.send(.chooseTrump(.hearts))
+    #expect(model.match.hand.phase == .playing)
+    model.send(.play(try #require(model.humanCards.first)))
+    #expect(model.match.hand.currentTrick.count == 1)
+}
+
+@MainActor @Test func acceptedHumanMoveSavesAndInvalidMoveShowsError() throws {
+    let deck = Suit.allCases.flatMap { suit in Rank.allCases.map { Card(suit, $0) } }
+    let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    defer { try? FileManager.default.removeItem(at: url) }
+    let model = GameModel(match: try Match(deck: deck, dealer: 3), saveURL: url)
+    model.send(.bid(1))
+    #expect(model.errorMessage != nil)
+    #expect(model.match.hand.nextSeat == 0)
+    model.send(.bid(2))
+    #expect(model.errorMessage == nil)
+    let restored = try MatchSave.read(from: url)
+    #expect(restored.hand.auction.highestBid == 2)
+    #expect(restored.hand.nextSeat == 1)
+}

--- a/docs/catch-five-rules.md
+++ b/docs/catch-five-rules.md
@@ -1,0 +1,21 @@
+# Catch 5 house rules
+
+Four players, two partnerships seated opposite; standard 52-card deck. First team to 25 wins. If both reach 25 on the same hand, the bidding team wins.
+
+Deal six cards each. Bidding starts left of dealer and ends with dealer. Minimum 2, maximum normal bid 9. Non-dealers must raise; dealer may match the highest bid and must bid 2 if everyone passes. Bid winner chooses trump. Discard all non-trumps and replenish each hand to six. Undealt cards remain out of play, including scoring cards.
+
+Bid winner leads any suit. Players must follow suit if able; otherwise any card is legal. Highest trump wins, otherwise highest card of the led suit. Trick winner leads next.
+
+Points are awarded to capturing teams: highest trump played (1), lowest trump played (1), trump Jack (1), trump Five (5). High/Low are relative to cards actually played, not necessarily Ace/2. Missing Jack/Five contribute no points.
+
+Game (1) goes to the team with the greatest captured-card value across all suits: 10=10, J=1, Q=2, K=3, A=4; all others=0. Ties go to the bidding team.
+
+Successful normal bidders add every point collected; unsuccessful bidders subtract their bid. Defenders always add their points.
+
+A special 9 and out bid is forbidden below zero. At zero or above, collecting all nine points wins the match; collecting fewer loses the match regardless of normal scores.
+
+## Pending rare-case clarification
+Whether the dealer can match a special 9 and out declaration, and whether that declaration may overcall a normal 9, are not yet confirmed. The first milestone validates normal auctions and special match settlement separately; it does not silently choose special-auction precedence.
+
+## Delivery
+Approved direction: pure Swift engine and tests first, then offline SwiftUI play with one human and three computer players, save/resume and hand scoring explanations. No multiplayer in the initial playable version.

--- a/docs/code-map.md
+++ b/docs/code-map.md
@@ -25,6 +25,7 @@ The screen sends an action, such as “Seat 0 plays the queen of clubs.” Match
 | `Sources/CatchFive/Hand.swift` | `Tests/CatchFiveTests/HandTests.swift` | 208 repeatable hands; no duplicate or missing cards |
 | `Sources/CatchFive/Match.swift` | `Tests/CatchFiveTests/MatchTests.swift` | Five full hands ending 26–16, then reject further play |
 | `Sources/CatchFive/MatchSave.swift` | `Tests/CatchFiveTests/SaveTests.swift` | Resume during bidding, trump selection, a trick, or between hands |
+| `Sources/CatchFive/ComputerPlayer.swift` | `Tests/CatchFiveTests/ComputerPlayerTests.swift` | 24 shuffled matches using only restricted observations, then save/load |
 | `Sources/CatchFiveDemo/main.swift` | Run `swift run catch-five-demo` | Calls Match; does not maintain a separate score implementation |
 
 ## Follow One Test
@@ -41,7 +42,7 @@ A fixed deck makes a failure repeatable. Small rule tests explain exactly which 
 
 ## What Is Not Built Yet
 
-Strategic computer players and the SwiftUI screen. Engine save/read APIs exist; automatic app lifecycle saving still needs the UI integration. Normal bidding works end to end. 9-and-out settlement is tested independently; its auction precedence still needs confirmation before connecting it to Match.
+The SwiftUI screen and stronger computer strategy. Baseline heuristic players now work. Engine save/read APIs exist; automatic app lifecycle saving still needs the UI integration. Normal bidding works end to end. 9-and-out settlement is tested independently; its auction precedence still needs confirmation before connecting it to Match.
 
 
 ## Following Functions Without Xcode
@@ -87,3 +88,21 @@ Only successful actions enter the log. Replay rejects illegal actions and invali
 Run `swift run catch-five-demo --save-roundtrip` to watch the demo resume after three plays and continue to the same 26–16 finish.
 
 Editor references: https://code.visualstudio.com/docs/languages/swift and https://www.swift.org/documentation/articles/getting-started-with-cursor-swift.html.
+
+
+## Computer Player Path
+
+```text
+ComputerPlayerTests.computersCompleteShuffledMatchesThroughRealRules
+  -> PlayerView(match:seat:)       // copy only own cards and public information
+  -> ComputerPlayer.decide         // select a strategy action
+    -> bidAmount / preferredSuit / chooseCard
+  -> Match.apply                   // referee still checks the proposed action
+    -> Match.bid / chooseTrump / play
+  -> normal scoring and victory
+  -> save/load finished match
+```
+
+Responsibility: PlayerView answers “what can this player know?” ComputerPlayer answers “what should it try?” Match answers “is that action allowed, and what happens next?” These are deliberately separate. The strategy is a deterministic baseline: favor strong suits, avoid bidding against partner, preserve the Five when losing, and feed points to a winning partner when last to act. Tests establish legal behavior and completion, not expert strength. It does not yet remember previous tricks or attempt 9 and out.
+
+Try `swift run catch-five-demo --computer` for a narrated match with fresh shuffled decks.

--- a/docs/code-map.md
+++ b/docs/code-map.md
@@ -1,0 +1,43 @@
+# Catch 5: From Rule to Running Game
+
+## Big Picture
+
+```mermaid
+flowchart TD
+    Demo[Text demo now / SwiftUI screen later] --> Match[Match: whole game and scores]
+    Match --> Hand[Hand: one deal and whose turn]
+    Hand --> Bidding[Bidding: who wins the auction]
+    Hand --> Tricks[Tricks: legal cards and trick winner]
+    Hand --> Scoring[Scoring: points earned]
+    Match --> Scoring
+```
+
+The screen sends an action, such as “Seat 0 plays the queen of clubs.” Match sends it to Hand. Hand checks turn order, card ownership and following suit. The fourth card resolves a trick. The sixth completed trick resolves a hand. Match then updates scores once, saves a hand summary and checks for a winner.
+
+## Source-to-Test Connections
+
+| Source | Direct tests | Whole-game connection |
+|---|---|---|
+| `Sources/CatchFive/Cards.swift` | `Tests/CatchFiveTests/TrickTests.swift` — cardValuesForGame | Captured values contribute to Game |
+| `Sources/CatchFive/Bidding.swift` | `Tests/CatchFiveTests/BiddingTests.swift` | HandTests verifies winning dealer chooses trump |
+| `Sources/CatchFive/Tricks.swift` | `Tests/CatchFiveTests/TrickTests.swift` | HandTests enforces following suit and next leader |
+| `Sources/CatchFive/Scoring.swift` | `Tests/CatchFiveTests/ScoringTests.swift` | MatchTests checks actual hand and match totals |
+| `Sources/CatchFive/Hand.swift` | `Tests/CatchFiveTests/HandTests.swift` | 208 repeatable hands; no duplicate or missing cards |
+| `Sources/CatchFive/Match.swift` | `Tests/CatchFiveTests/MatchTests.swift` | Five full hands ending 26–16, then reject further play |
+| `Sources/CatchFiveDemo/main.swift` | Run `swift run catch-five-demo` | Calls Match; does not maintain a separate score implementation |
+
+## Follow One Test
+
+`matchScoresOnlyAfterLastCardAndOnlyOnce` is a useful starting point:
+
+1. Create a real Match with a fixed deck.
+2. Send real bids and choose trump.
+3. Play 23 legal cards; expect scores `[0, 0]` and no history.
+4. Play card 24; expect scores `[2, 7]` and one hand summary.
+5. Attempt another play; expect rejection and unchanged scores.
+
+A fixed deck makes a failure repeatable. Small rule tests explain exactly which behavior broke; full-game tests catch pieces that work separately but are connected incorrectly.
+
+## What Is Not Built Yet
+
+Strategic computer players, persistent save/resume, and the SwiftUI screen. Normal bidding works end to end. 9-and-out settlement is tested independently; its auction precedence still needs confirmation before connecting it to Match.

--- a/docs/code-map.md
+++ b/docs/code-map.md
@@ -24,6 +24,7 @@ The screen sends an action, such as “Seat 0 plays the queen of clubs.” Match
 | `Sources/CatchFive/Scoring.swift` | `Tests/CatchFiveTests/ScoringTests.swift` | MatchTests checks actual hand and match totals |
 | `Sources/CatchFive/Hand.swift` | `Tests/CatchFiveTests/HandTests.swift` | 208 repeatable hands; no duplicate or missing cards |
 | `Sources/CatchFive/Match.swift` | `Tests/CatchFiveTests/MatchTests.swift` | Five full hands ending 26–16, then reject further play |
+| `Sources/CatchFive/MatchSave.swift` | `Tests/CatchFiveTests/SaveTests.swift` | Resume during bidding, trump selection, a trick, or between hands |
 | `Sources/CatchFiveDemo/main.swift` | Run `swift run catch-five-demo` | Calls Match; does not maintain a separate score implementation |
 
 ## Follow One Test
@@ -40,4 +41,49 @@ A fixed deck makes a failure repeatable. Small rule tests explain exactly which 
 
 ## What Is Not Built Yet
 
-Strategic computer players, persistent save/resume, and the SwiftUI screen. Normal bidding works end to end. 9-and-out settlement is tested independently; its auction precedence still needs confirmation before connecting it to Match.
+Strategic computer players and the SwiftUI screen. Engine save/read APIs exist; automatic app lifecycle saving still needs the UI integration. Normal bidding works end to end. 9-and-out settlement is tested independently; its auction precedence still needs confirmation before connecting it to Match.
+
+
+## Following Functions Without Xcode
+
+Use VS Code or Cursor with the official Swift extension. Open the repository folder containing Package.swift, not an individual file. The Swift extension supplies Go to Definition, Peek Definition, Find All References and test/debugging support.
+
+- **Go to Definition** answers “what does this function actually do?”
+- **Find All References** answers “who uses this function?”
+- **Outline / Go to Symbol** lists the functions and types in the current file.
+- **Debugger Step Into** follows a call while a real scenario runs; **Step Over** runs a call without descending into it. Set a breakpoint in Match.play and debug a Match test.
+
+Start with a scenario, not the alphabetic file list. Trace these exact calls:
+
+```text
+MatchTests.matchScoresOnlyAfterLastCardAndOnlyOnce
+  -> playCards
+    -> Match.play
+      -> Hand.play
+        -> Hand.legalMoves -> legalCards
+        -> Hand.finishTrick (fourth card only)
+          -> trickWinner
+          -> scoreHand (sixth trick only)
+      -> Match.recordHand (finished hand only)
+        -> settle
+```
+
+Track three things at each call: its inputs, what state it changes, and its result/error. Most of our types are structs (value types); `mutating` means the method changes that value. `private(set)` lets other code read a property but makes its owner responsible for changing it.
+
+## Save/Resume Path
+
+```text
+SaveTests.saveRestoresEveryPhaseAndContinuesIdentically
+  -> MatchSave.encode -> versioned JSON: initial deck + accepted actions
+  -> MatchSave.decode -> new Match
+    -> SavedAction.apply -> ordinary bid / chooseTrump / play / startNextHand
+  -> continue playing -> same final score
+```
+
+Disk connection: MatchSave.write uses atomic file replacement; MatchSave.read loads bytes and passes them to decode. Tests use a temporary directory and check replacing a save as well as reporting missing/unwritable paths.
+
+Only successful actions enter the log. Replay rejects illegal actions and invalid decks. Format version 1 ties a save to the current rules/replay behavior; future incompatible rule changes need an explicit migration or version bump. Replay time grows with the number of actions, which is acceptable for this initial local game but should be measured for unusually long matches.
+
+Run `swift run catch-five-demo --save-roundtrip` to watch the demo resume after three plays and continue to the same 26–16 finish.
+
+Editor references: https://code.visualstudio.com/docs/languages/swift and https://www.swift.org/documentation/articles/getting-started-with-cursor-swift.html.

--- a/docs/engine-plan.md
+++ b/docs/engine-plan.md
@@ -1,0 +1,26 @@
+# Catch Five Engine Implementation Plan
+
+> Execute inline task-by-task using test-driven development. No commits without user instruction.
+
+**Goal:** Deliver independently tested rule primitives before implementing the full hand lifecycle.
+
+**Architecture:** Pure Swift value types and throwing validation functions. No SwiftUI, network, or external packages. A later match coordinator will use these same functions for human and computer actions.
+
+**Tech Stack:** Swift 6, Swift Testing, iOS 17+/macOS 14+ package deployment targets.
+
+**Spec:** `docs/catch-five-rules.md`
+
+## Global Constraints
+- User house rules override standard Pitch.
+- Keep special bid auction precedence unresolved until confirmed.
+- No commits or remote writes.
+
+## Tasks
+- [x] Create `Cards.swift` with Card/Suit/Rank and `Tricks.swift` with `legalCards(in:led:)` and `trickWinner(_:trump:)`. Tests reject empty/malformed tricks and distinguish following suit from trumping. Example: `#expect(legalCards(in: hand, led: .clubs) == [club])`.
+- [x] Create `Bidding.swift` with a four-turn `Auction`, `Bid`, and checked `act(seat:bid:)`. Tests exercise minimum/maximum bids, forced dealer, matching, completion and out-of-turn actions. Example: `#expect(auction.winner == 3)` after the dealer matches 4.
+- [x] Create `Scoring.swift` with `scoreHand(captured:trump:bidder:)` and `settle(scores:points:bidder:bid:)`. Test relative High/Low, absent scoring cards, all-suit Game ties, negative set scores, target ties and 9-and-out results. Example: `#expect(result.winner == 1)` when team 0 misses 9 and out.
+- [x] For each unit: write tests, run `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test` and observe failure, implement, rerun to green.
+- [x] Correct README, run complete suite and release build, inspect Git diff, report the tested milestone and remaining work.
+
+## Next Milestone
+Deal/refill and turn state machine; then deterministic complete-hand simulations, computer strategy, persistence, and SwiftUI integration. The present rules package is not a playable app.

--- a/docs/hand-plan.md
+++ b/docs/hand-plan.md
@@ -1,0 +1,15 @@
+# Hand Lifecycle Implementation Plan
+
+**Goal:** Run Catch 5 hands from an ordered deck through the final score without a screen.
+**Architecture:** A value-type Hand owns the auction, card locations, turn and completed tricks. Its methods validate before mutation. Tests supply ordered decks and legal automatic moves.
+**Spec:** `catch-five-rules.md`.
+
+- [x] Add `Sources/CatchFive/Hand.swift`: checked 52-card initialization, normal bidding, bidder-only trump selection, discard/refill, checked card play and final scoring.
+- [x] Add `Tests/CatchFiveTests/HandTests.swift`: initial dealing/card conservation, illegal-phase and ownership errors, refill, follow-suit enforcement, completed trick leader and final scoring. Write tests against empty operations, observe failure, implement and verify.
+- [x] Run repeatable simulations across all dealer seats and trump suits, checking 52 unique cards across all locations after every move and termination after 24 plays.
+- [x] Add a terminal demonstration to narrate one hand, then verify tests and the demonstration. Document actual status.
+
+Implementation defaults: initial deal in two rounds of three, clockwise starting left of dealer; refill clockwise starting left of dealer, one player's replacement batch at a time. These packet-order details were not explicitly specified and are recorded as defaults, not confirmed house rules. Only non-trumps from the initial hand are discarded; replacement cards remain regardless of suit. Normal auction only until special-bid precedence is clarified.
+
+## Verification and Handoff
+24 tests pass, including 208 deterministic complete hands. Text demo completes in five hands with final scores 26–16. Files touched: Package.swift, Hand.swift, HandTests.swift, CatchFiveDemo/main.swift, README.md, AGENTS.md and this plan. No commits or pushes. Next: computer-player observations/strategy and persistent match lifecycle. Special-auction precedence remains the only outstanding rule question.

--- a/docs/match-plan.md
+++ b/docs/match-plan.md
@@ -1,0 +1,20 @@
+# Match Coordinator Plan
+
+Approved direction: continue the pure Swift engine, explaining source-to-test connections.
+
+## Scope
+`Match` wraps `Hand` and owns scores, hand number, hand summaries and match winner. It automatically settles the final play exactly once and requires an explicit next-hand action so a future screen can show the scoring breakdown. It reuses `settle` rather than duplicating scoring rules. Normal bidding remains the supported auction path; special-auction precedence is still pending.
+
+## Pipeline
+House rule -> `Tests/CatchFiveTests/MatchTests.swift` -> `Sources/CatchFive/Match.swift` -> `Sources/CatchFiveDemo/main.swift`.
+
+- [x] Write failing lifecycle tests: prevent premature redeal; score final card once; preserve state on invalid actions; rotate dealer; reject play after match victory.
+- [x] Implement checked actions and hand summaries in Match.swift.
+- [x] Test the full five-hand fixture with independently checked scores `[2,7]`, `[10,5]`, `[12,12]`, `[19,14]`, `[26,16]`.
+- [x] Connect the terminal demo to Match so demonstration and future UI share the real match coordinator.
+- [x] Run suite, demo, release build and iOS Simulator type check. Update project status and source/test map.
+
+No commits or remote writes. Save/resume and computer strategy remain subsequent milestones.
+
+## Handoff
+Implemented Match.swift and six MatchTests; connected the demo to Match; added docs/code-map.md and updated README/AGENTS status. 30 tests pass. No commits or pushes. Next: save/resume and computer-player strategy; special-auction precedence remains unresolved.

--- a/project.yml
+++ b/project.yml
@@ -1,0 +1,33 @@
+name: CatchFive
+options:
+  bundleIdPrefix: com.cardgame
+  deploymentTarget:
+    iOS: "17.0"
+packages:
+  CatchFivePackage:
+    path: .
+targets:
+  CatchFiveApp:
+    type: application
+    platform: iOS
+    sources: [App]
+    dependencies:
+      - package: CatchFivePackage
+        product: CatchFiveUI
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.cardgame.catchfive
+        GENERATE_INFOPLIST_FILE: YES
+        INFOPLIST_KEY_CFBundleDisplayName: Catch 5
+        INFOPLIST_KEY_UILaunchScreen_Generation: YES
+        INFOPLIST_KEY_UISupportedInterfaceOrientations: UIInterfaceOrientationPortrait
+        SWIFT_VERSION: "6.0"
+        TARGETED_DEVICE_FAMILY: "1,2"
+        CODE_SIGN_STYLE: Automatic
+schemes:
+  CatchFiveApp:
+    build:
+      targets:
+        CatchFiveApp: all
+    run:
+      config: Debug

--- a/scripts/build-simulator.py
+++ b/scripts/build-simulator.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Build the simulator app directly when Xcode's destination discovery is unavailable."""
+import os
+from pathlib import Path
+import plistlib
+import subprocess
+
+root = Path(__file__).resolve().parents[1]
+out = root / 'work' / 'simulator-build'
+app = out / 'CatchFive.app'
+app.mkdir(parents=True, exist_ok=True)
+env = dict(os.environ, DEVELOPER_DIR=os.environ.get('DEVELOPER_DIR', '/Applications/Xcode.app/Contents/Developer'))
+sdk = subprocess.check_output(['xcrun', '--sdk', 'iphonesimulator', '--show-sdk-path'], env=env, text=True).strip()
+base = ['xcrun', 'swiftc', '-sdk', sdk, '-target', 'arm64-apple-ios17.0-simulator', '-swift-version', '6', '-I', str(out), '-L', str(out)]
+
+def run(args):
+    subprocess.run(args, env=env, cwd=root, check=True)
+
+for module in ['CatchFive', 'CatchFiveUI']:
+    sources = sorted(str(p) for p in (root / 'Sources' / module).glob('*.swift'))
+    run(base + ['-emit-library', '-static', '-emit-module', '-module-name', module,
+                '-emit-module-path', str(out / (module + '.swiftmodule')),
+                '-o', str(out / ('lib' + module + '.a'))] + sources)
+run(base + ['-module-name', 'CatchFiveApp', '-parse-as-library', str(root / 'App' / 'CatchFiveApp.swift'),
+            '-lCatchFiveUI', '-lCatchFive', '-o', str(app / 'CatchFive')])
+info = dict(CFBundleIdentifier='com.cardgame.catchfive', CFBundleName='CatchFive',
+            CFBundleDisplayName='Catch 5', CFBundleExecutable='CatchFive', CFBundlePackageType='APPL',
+            CFBundleShortVersionString='0.1', CFBundleVersion='1', MinimumOSVersion='17.0',
+            LSRequiresIPhoneOS=True, UIDeviceFamily=[1, 2], UILaunchScreen={},
+            UISupportedInterfaceOrientations=['UIInterfaceOrientationPortrait'])
+with (app / 'Info.plist').open('wb') as file:
+    plistlib.dump(info, file)
+run(['codesign', '--force', '--sign', '-', str(app)])
+print(app)


### PR DESCRIPTION
## Summary

Brings the Catch 5 (Pitch with Fives) game from an empty repo to a playable iOS app against three computer seats.

- **Rules engine** (`Sources/CatchFive`): dealing and refill, four-seat auction including 9-and-out bids, follow-suit validation, trick capture, High/Low/Jack/Five/Game scoring, and a `Match` coordinator that owns scores, hand history, dealer rotation, and the 25-point win.
- **Computer players**: baseline bidding, trump choice, and card play using a restricted `PlayerView` so they never see opponents' cards.
- **Save/resume**: versioned replay-based saves with atomic writes. A restored match replays the action log through the same rules path as live play.
- **SwiftUI app** (`Sources/CatchFiveUI`, `App/`): `GameModel` view model plus a `TableView` that persists every accepted action and restores on launch. The player's hand sits above the bid controls, and the last-trick panel names who took it and who leads next.
- **Tooling**: xcodegen `project.yml`, a checked-in Xcode project, and `scripts/build-simulator.py` for building with `swiftc` when xcodebuild can't resolve a simulator destination.

House rules in `docs/catch-five-rules.md` take precedence over published Pitch rules. Special-bid auction precedence beyond 9-and-out is still an open question.

## Test plan

- [x] `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test` — 51 tests pass, including 208 deterministic hands and 24 shuffled computer matches
- [x] `swift run catch-five-demo` completes a five-hand text match; `--save-roundtrip` and `--computer` modes run
- [x] Played a full hand in the iOS simulator, reinstalled and relaunched twice mid-game; the app restored the same position and `game.json` was byte-identical after relaunch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
