### PR TITLE
Auction display, calibrated bidding, trick animation and explainer docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,9 @@ Use Swift Testing and a dependency-free Swift package for rules. SwiftUI and a t
 ## Aesthetic North Star
 A readable, welcoming card table with large cards and understated controls. Final visual design awaits the playable engine.
 
+## Living documentation
+`docs/learning-path.md` indexes explainer pages (architecture, game-flow, types-and-functions, testing, decisions, build-and-run) with Mermaid diagrams. Any commit that adds, renames or removes a type, function, phase or test must update the matching page in the same commit, and new design choices get a numbered entry in `docs/decisions.md`.
+
 ## Verification
 Run `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # CardGame.io
 
 ## Current Status
-Greenfield SwiftUI iOS app. Rules and complete hand lifecycle implemented: deal/refill, normal auction, legal moves, trick capture, scoring and match settlement. 46 tests pass, including 208 deterministic hands and a five-hand match. Match owns automatic scoring, summaries, dealer rotation and victory enforcement; terminal demo uses it. Versioned replay-based save/resume and atomic disk APIs are implemented; baseline computer players use restricted PlayerView, with 24 shuffled match simulations. No automatic app lifecycle saving or app UI yet.
+Greenfield SwiftUI iOS app. Rules and complete hand lifecycle implemented: deal/refill, normal auction, legal moves, trick capture, scoring and match settlement. 55 tests pass, including 208 deterministic hands and a five-hand match. Match owns automatic scoring, summaries, dealer rotation and victory enforcement; terminal demo uses it. Versioned replay-based save/resume and atomic disk APIs are implemented; baseline computer players use restricted PlayerView, with 24 shuffled match simulations. SwiftUI table (`Sources/CatchFiveUI`) plays one human against three computers, shows each seat's auction call and the contract, and saves after every accepted action and on backgrounding. Build the simulator bundle with `scripts/build-simulator.py`.
 
 ## Architecture
 Use Swift Testing and a dependency-free Swift package for rules. SwiftUI and a thin view model will consume it. Team 0 seats are 0/2, team 1 seats are 1/3; turns advance in ascending seat order modulo four.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Initial dealing uses two packets of three starting left of dealer. Refill gives 
 
 - `Sources/CatchFive`: pure Swift rules; no UI dependencies.
 - `Tests/CatchFiveTests`: repeatable rule tests with explicit card fixtures.
-- `docs/catch-five-rules.md`: confirmed house rules and unresolved cases.
+- `docs/learning-path.md`: start here to read the code without an IDE; links the architecture, game-flow, types, testing, decision-log and build pages, all with diagrams.
+- `docs/catch-five-rules.md`: confirmed house rules.
 - `docs/engine-plan.md`: initial implementation milestone.
 - `docs/code-map.md`: plain-language architecture and source-to-test connections.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A SwiftUI iOS card-game app in development, starting with Catch 5 (Pitch with Fi
 
 ## Current Status
 
-The pure Swift engine now runs complete hands and a repeatable text demonstration runs a normal-bid match to completion. There is no playable iOS app yet.
+The pure Swift engine runs complete matches, and a SwiftUI table lets one human play against three computer players with automatic save and restore. A repeatable text demonstration also runs a normal-bid match to completion.
 
 - Normal four-seat bidding with dealer matching and forced opening bid.
 - Follow-suit validation and trick winner calculation.
@@ -13,10 +13,12 @@ The pure Swift engine now runs complete hands and a repeatable text demonstratio
 - Full deal, discard/refill, bidding-to-play transitions, turn enforcement and six-trick completion.
 - Match coordinator with automatic scoring, hand history, dealer rotation and victory enforcement.
 - Versioned save/resume with validated action replay and atomic file writes.
-- Baseline computer bidding, trump selection and card play using only a restricted PlayerView.
-- 46 Swift Testing tests, including 208 deterministic hands and 24 shuffled computer matches.
+- Baseline computer bidding, trump selection and card play using only a restricted PlayerView; leads keep the trump five back.
+- Auction call history per seat, shown on the table during bidding and summarised as the contract afterwards.
+- SwiftUI table with bidding, trump choice, legal-card play, last-trick recap, hand summary and save on every accepted action.
+- 55 Swift Testing tests, including 208 deterministic hands and 24 shuffled computer matches.
 
-`Auction` currently accepts normal integer bids only. Special bid precedence awaits a house-rule clarification; 9-and-out win/loss settlement is already tested separately.
+`Auction` accepts normal bids and 9-and-out, treating 9-and-out as outranking a normal 9 with dealer matching allowed. Whether that precedence matches the house rule is still unconfirmed.
 
 ## Run Tests
 
@@ -54,6 +56,6 @@ Team-indexed inputs use `[team0, team1]`. Team 0 seats are 0/2, team 1 seats are
 
 ## Next
 
-Add a SwiftUI interface with a thin view model and refine computer strategy through playtesting. Special-bid auction precedence remains unresolved.
+Refine computer strategy through playtesting and confirm special-bid auction precedence. Build the simulator app with `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer python3 scripts/build-simulator.py` when Xcode's iOS platform is unavailable.
 
-Development branch: `feature/catch-five-engine`. Use tested milestone commits to track progress.
+Use tested milestone commits on short-lived branches off `main` to track progress.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The pure Swift engine runs complete matches, and a SwiftUI table lets one human 
 - SwiftUI table with bidding, trump choice, legal-card play, last-trick recap, hand summary and save on every accepted action.
 - 55 Swift Testing tests, including 208 deterministic hands and 24 shuffled computer matches.
 
-`Auction` accepts normal bids and 9-and-out, treating 9-and-out as outranking a normal 9 with dealer matching allowed. Whether that precedence matches the house rule is still unconfirmed.
+`Auction` accepts normal bids and 9-and-out, treating 9-and-out as outranking a normal 9 with dealer matching allowed. Both are confirmed house rules.
 
 ## Run Tests
 
@@ -56,6 +56,6 @@ Team-indexed inputs use `[team0, team1]`. Team 0 seats are 0/2, team 1 seats are
 
 ## Next
 
-Refine computer strategy through playtesting and confirm special-bid auction precedence. Build the simulator app with `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer python3 scripts/build-simulator.py` when Xcode's iOS platform is unavailable.
+Refine computer strategy through playtesting. Build the simulator app with `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer python3 scripts/build-simulator.py` when Xcode's iOS platform is unavailable.
 
 Use tested milestone commits on short-lived branches off `main` to track progress.

--- a/Sources/CatchFive/Bidding.swift
+++ b/Sources/CatchFive/Bidding.swift
@@ -3,9 +3,22 @@ public enum Bid: Equatable, Sendable {
     case nineAndOut
 }
 
+/// One seat's turn in the auction; a nil bid is a pass.
+public struct AuctionCall: Equatable, Sendable {
+    public let seat: Int
+    public let bid: Bid?
+
+    public init(seat: Int, bid: Bid?) {
+        self.seat = seat
+        self.bid = bid
+    }
+}
+
 /// One bidding round; nine and out outranks normal nine and dealer may match.
 public struct Auction: Sendable {
     public private(set) var isNineAndOut = false
+    /// Every accepted call in seat order; rejected calls are not recorded.
+    public private(set) var calls: [AuctionCall] = []
     public let dealer: Int
     public private(set) var nextSeat: Int?
     public private(set) var winner: Int?
@@ -33,6 +46,7 @@ public struct Auction: Sendable {
         } else if seat == dealer && highestBid == nil {
             throw RuleError.invalidBid
         }
+        calls.append(AuctionCall(seat: seat, bid: nineAndOut ? .nineAndOut : bid.map(Bid.points)))
         self.nextSeat = seat == dealer ? nil : (seat + 1) % 4
     }
 }

--- a/Sources/CatchFive/ComputerPlayer.swift
+++ b/Sources/CatchFive/ComputerPlayer.swift
@@ -9,6 +9,21 @@ public struct PlayerView: Sendable {
     public let bidder: Int?
     public let trump: Suit?
     public let trick: [Play]
+    public let calls: [AuctionCall]
+
+    public init(seat: Int, cards: [Card], phase: HandPhase, nextSeat: Int?, dealer: Int,
+                highestBid: Int?, bidder: Int?, trump: Suit?, trick: [Play], calls: [AuctionCall] = []) {
+        self.seat = seat
+        self.cards = cards
+        self.phase = phase
+        self.nextSeat = nextSeat
+        self.dealer = dealer
+        self.highestBid = highestBid
+        self.bidder = bidder
+        self.trump = trump
+        self.trick = trick
+        self.calls = calls
+    }
 }
 
 extension PlayerView {
@@ -18,7 +33,8 @@ extension PlayerView {
         self.init(seat: seat, cards: hand.hands[seat], phase: hand.phase,
                   nextSeat: match.winner == nil ? hand.nextSeat : nil,
                   dealer: hand.auction.dealer, highestBid: hand.auction.highestBid,
-                  bidder: hand.auction.winner, trump: hand.trump, trick: hand.currentTrick)
+                  bidder: hand.auction.winner, trump: hand.trump, trick: hand.currentTrick,
+                  calls: hand.auction.calls)
     }
 }
 
@@ -65,8 +81,10 @@ public enum ComputerPlayer {
         guard let trump = view.trump else { return nil }
         let legal = legalCards(in: view.cards, led: view.trick.first?.card.suit)
         guard let lead = view.trick.first else {
-            // Lead a high card to gain control; this is a baseline heuristic.
-            return legal.max { rank($0, led: trump, trump: trump) < rank($1, led: trump, trump: trump) }
+            // Lead a high card to gain control, but never expose the trump five when another lead exists.
+            let leads = legal.filter { $0 != Card(trump, .five) }
+            return (leads.isEmpty ? legal : leads)
+                .max { rank($0, led: trump, trump: trump) < rank($1, led: trump, trump: trump) }
         }
         let current = view.trick.max { rank($0.card, led: lead.card.suit, trump: trump)
             < rank($1.card, led: lead.card.suit, trump: trump) }!

--- a/Sources/CatchFive/ComputerPlayer.swift
+++ b/Sources/CatchFive/ComputerPlayer.swift
@@ -58,21 +58,34 @@ public enum ComputerPlayer {
 
     private static func preferredSuit(_ cards: [Card]) -> Suit {
         // Fixed suit order makes equal-strength choices repeatable.
-        Suit.allCases.max { strength(cards, suit: $0) < strength(cards, suit: $1) } ?? .clubs
+        Suit.allCases.max { estimate(cards, suit: $0) < estimate(cards, suit: $1) } ?? .clubs
     }
 
-    private static func strength(_ cards: [Card], suit: Suit) -> Int {
-        cards.filter { $0.suit == suit }.reduce(0) { total, card in
-            total + 2 + (card.rank.rawValue >= Rank.jack.rawValue ? 2 : 0)
-                + (card.rank == .five ? 2 : 0)
+    /// Expected hand points if `suit` were trump, judged before the discard and refill.
+    /// Weights are playtesting heuristics, not derived probabilities.
+    static func estimate(_ cards: [Card], suit: Suit) -> Double {
+        let trumps = cards.filter { $0.suit == suit }.map(\.rank.rawValue).sorted()
+        guard let top = trumps.last, let bottom = trumps.first else { return 0 }
+        let control = trumps.filter { $0 >= Rank.king.rawValue }.count
+        var points = 0.0
+        points += [Rank.ace.rawValue: 1.0, Rank.king.rawValue: 0.75, Rank.queen.rawValue: 0.45][top] ?? 0.2
+        points += [Rank.two.rawValue: 1.0, Rank.three.rawValue: 0.75, Rank.four.rawValue: 0.5][bottom] ?? 0.2
+        if trumps.contains(Rank.jack.rawValue) { points += control > 0 ? 0.8 : 0.4 }
+        if trumps.contains(Rank.five.rawValue) {
+            points += 2.5 + Double(control) * 0.75 + Double(trumps.count - 1) * 0.25
+        } else if control >= 2 {
+            points += 0.75
         }
+        points += 0.5 + Double(max(0, trumps.count - 2)) * 0.3
+        points += Double(6 - trumps.count) * 0.1 // Refill may bring more trumps.
+        return points
     }
 
     private static func bidAmount(_ view: PlayerView) -> Int? {
         if let bidder = view.bidder, bidder % 2 == view.seat % 2 { return nil }
         let needed = view.highestBid.map { $0 + (view.seat == view.dealer ? 0 : 1) } ?? 2
-        let confidence = min(5, strength(view.cards, suit: preferredSuit(view.cards)) / 3)
-        if needed <= confidence { return needed }
+        let confidence = Int((estimate(view.cards, suit: preferredSuit(view.cards)) - 0.5).rounded(.down))
+        if needed <= min(confidence, 9) { return needed }
         if view.seat == view.dealer && view.highestBid == nil { return 2 }
         return nil
     }

--- a/Sources/CatchFiveUI/GameModel.swift
+++ b/Sources/CatchFiveUI/GameModel.swift
@@ -29,6 +29,26 @@ public final class GameModel: ObservableObject {
         }
     }
 
+    /// Wording for a seat's most recent auction call, or nil if that seat has not called yet.
+    public func latestCall(for seat: Int) -> String? {
+        match.hand.auction.calls.last { $0.seat == seat }.map { call in
+            switch call.bid {
+            case nil: "Pass"
+            case .nineAndOut: "9 and out"
+            case let .points(amount): "Bid \(amount)"
+            }
+        }
+    }
+
+    /// Who won the auction and for how much, once bidding has ended.
+    public var contract: String? {
+        let auction = match.hand.auction
+        guard auction.nextSeat == nil, let bidder = auction.winner, let bid = auction.highestBid else { return nil }
+        return "\(Self.seatNames[bidder]) bid \(auction.isNineAndOut ? "9 and out" : String(bid))"
+    }
+
+    public static let seatNames = ["You", "West", "Partner", "East"]
+
     public func allows(_ action: PlayerAction) -> Bool {
         guard isHumanTurn else { return false }
         var copy = match

--- a/Sources/CatchFiveUI/TableView.swift
+++ b/Sources/CatchFiveUI/TableView.swift
@@ -124,17 +124,33 @@ public struct TableView: View {
                     .font(.footnote).foregroundStyle(.gold)
             }
             HStack(spacing: 12) {
-                ForEach(plays, id: \.seat) { play in
+                // Cards are unique within a hand, so keying by card lets a new trick replace the last one.
+                ForEach(plays, id: \.card) { play in
                     VStack(spacing: 8) {
                         CardView(card: play.card)
-                        Text(["You", "West", "Partner", "East"][play.seat]).font(.caption2)
+                            .overlay(RoundedRectangle(cornerRadius: 8)
+                                .stroke(.gold, lineWidth: showingLast && last?.winner == play.seat ? 3 : 0))
+                        Text(names[play.seat]).font(.caption2)
                     }
+                    .transition(.asymmetric(insertion: .move(edge: Self.edge(for: play.seat)).combined(with: .opacity),
+                                            removal: .opacity))
                 }
                 if plays.isEmpty { Text("Waiting for the first card").font(.footnote).opacity(0.45).frame(height: 96) }
             }.frame(minHeight: 96)
+            .animation(.spring(duration: 0.45), value: model.revision)
         }.frame(maxWidth: .infinity).padding(.vertical, 20)
             .background(.white.opacity(0.025), in: RoundedRectangle(cornerRadius: 24))
             .overlay(RoundedRectangle(cornerRadius: 24).stroke(.white.opacity(0.08)))
+    }
+
+    /// Played cards enter from the side of the table their seat occupies.
+    private static func edge(for seat: Int) -> Edge {
+        switch seat {
+        case 1: .leading
+        case 2: .top
+        case 3: .trailing
+        default: .bottom
+        }
     }
 
     @ViewBuilder private var controls: some View {
@@ -181,8 +197,10 @@ public struct TableView: View {
                             .buttonStyle(.plain)
                             .allowsHitTesting(playable)
                             .opacity(model.match.hand.phase == .playing && !playable ? 0.5 : 1)
+                            .transition(.asymmetric(insertion: .opacity, removal: .move(edge: .top).combined(with: .opacity)))
                     }
                 }.padding(.bottom, 8)
+                .animation(.spring(duration: 0.45), value: model.revision)
             }
         }
     }

--- a/Sources/CatchFiveUI/TableView.swift
+++ b/Sources/CatchFiveUI/TableView.swift
@@ -63,8 +63,13 @@ public struct TableView: View {
         HStack {
             score("YOU + PARTNER", value: model.match.scores[0])
             Spacer()
-            Text(model.match.hand.trump.map { "\($0.glyph)\nTRUMP" } ?? "—\nTRUMP")
-                .font(.caption.monospaced()).multilineTextAlignment(.center).foregroundStyle(.gold)
+            VStack(spacing: 4) {
+                Text(model.match.hand.trump.map { "\($0.glyph) TRUMP" } ?? "— TRUMP")
+                    .font(.caption.monospaced())
+                if let contract = model.contract {
+                    Text(contract).font(.system(size: 9, design: .monospaced)).opacity(0.8)
+                }
+            }.multilineTextAlignment(.center).foregroundStyle(.gold)
             Spacer()
             score("WEST + EAST", value: model.match.scores[1])
         }.padding(16).background(.white.opacity(0.06), in: RoundedRectangle(cornerRadius: 16))
@@ -80,10 +85,17 @@ public struct TableView: View {
     private func opponent(_ seat: Int, name: String) -> some View {
         VStack(spacing: 6) {
             Text(name).font(.subheadline.weight(.semibold))
-            Text("\(model.match.hand.hands[seat].count) cards").font(.caption2).opacity(0.65)
+            Text(seatDetail(seat)).font(.caption2).opacity(0.65)
             if model.match.hand.auction.dealer == seat { Text("DEALER").font(.system(size: 8, design: .monospaced)).foregroundStyle(.gold) }
         }.padding(12)
             .background(model.match.hand.nextSeat == seat ? .white.opacity(0.14) : .white.opacity(0.04), in: RoundedRectangle(cornerRadius: 12))
+    }
+
+    /// During the auction each seat shows its call; afterwards the bidder is marked and others show card counts.
+    private func seatDetail(_ seat: Int) -> String {
+        if model.match.hand.phase == .bidding { return model.latestCall(for: seat) ?? "Waiting" }
+        if model.match.hand.auction.winner == seat { return "Bidder" }
+        return "\(model.match.hand.hands[seat].count) cards"
     }
 
     private var status: String {
@@ -155,15 +167,20 @@ public struct TableView: View {
             HStack {
                 Text("YOUR HAND").font(.caption.monospaced()).tracking(1)
                 Spacer()
+                if model.match.hand.phase == .bidding, let call = model.latestCall(for: 0) {
+                    Text(call.uppercased()).font(.caption2.monospaced()).opacity(0.65)
+                }
                 if model.match.hand.auction.dealer == 0 { Text("DEALER").font(.caption2.monospaced()).foregroundStyle(.gold) }
             }
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 8) {
                     ForEach(model.humanCards, id: \.self) { card in
+                        // Hit testing rather than .disabled keeps the hand readable while bidding.
+                        let playable = model.allows(.play(card))
                         Button { model.send(.play(card)) } label: { CardView(card: card) }
                             .buttonStyle(.plain)
-                            .disabled(!model.allows(.play(card)))
-                            .opacity(model.match.hand.phase == .playing && !model.allows(.play(card)) ? 0.5 : 1)
+                            .allowsHitTesting(playable)
+                            .opacity(model.match.hand.phase == .playing && !playable ? 0.5 : 1)
                     }
                 }.padding(.bottom, 8)
             }

--- a/Tests/CatchFiveTests/BiddingTests.swift
+++ b/Tests/CatchFiveTests/BiddingTests.swift
@@ -59,3 +59,19 @@ import Testing
     #expect(auction.winner == 3)
     #expect(auction.isNineAndOut)
 }
+
+@Test func auctionRecordsEverySeatCallInOrder() throws {
+    var auction = try Auction(dealer: 3)
+    try auction.act(seat: 0, bid: nil)
+    try auction.act(seat: 1, bid: 3)
+    #expect(throws: RuleError.invalidBid) { try auction.act(seat: 2, bid: 3) }
+    try auction.act(seat: 2, bid: 9, nineAndOut: true)
+    try auction.act(seat: 3, bid: nil)
+    #expect(auction.calls == [
+        AuctionCall(seat: 0, bid: nil),
+        AuctionCall(seat: 1, bid: .points(3)),
+        AuctionCall(seat: 2, bid: .nineAndOut),
+        AuctionCall(seat: 3, bid: nil),
+    ])
+    #expect(auction.calls.first { $0.seat == 1 }?.bid == .points(3))
+}

--- a/Tests/CatchFiveTests/ComputerPlayerTests.swift
+++ b/Tests/CatchFiveTests/ComputerPlayerTests.swift
@@ -100,3 +100,19 @@ private struct RepeatableRandom: RandomNumberGenerator {
         #expect(restored.scores == match.scores)
     }
 }
+
+@Test func computerLeadsHighestTrumpButKeepsTheFiveBack() {
+    let cards = [Card(.hearts, .ace), Card(.hearts, .five), Card(.clubs, .ten)]
+    #expect(ComputerPlayer.decide(view(cards: cards)) == .play(Card(.hearts, .ace)))
+    let fiveOnlyTrump = [Card(.hearts, .five), Card(.clubs, .ten), Card(.spades, .king)]
+    #expect(ComputerPlayer.decide(view(cards: fiveOnlyTrump)) == .play(Card(.spades, .king)))
+    #expect(ComputerPlayer.decide(view(cards: [Card(.hearts, .five)])) == .play(Card(.hearts, .five)))
+}
+
+@Test func computerSeesPublicAuctionCalls() throws {
+    let deck = Suit.allCases.flatMap { suit in Rank.allCases.map { Card(suit, $0) } }
+    var match = try Match(deck: deck, dealer: 3)
+    try match.bid(seat: 0, amount: 4)
+    let view = try PlayerView(match: match, seat: 1)
+    #expect(view.calls == [AuctionCall(seat: 0, bid: .points(4))])
+}

--- a/Tests/CatchFiveTests/ComputerPlayerTests.swift
+++ b/Tests/CatchFiveTests/ComputerPlayerTests.swift
@@ -116,3 +116,36 @@ private struct RepeatableRandom: RandomNumberGenerator {
     let view = try PlayerView(match: match, seat: 1)
     #expect(view.calls == [AuctionCall(seat: 0, bid: .points(4))])
 }
+
+@Test func estimateRanksControlAndTheFiveAboveScatteredCards() {
+    let strong = [Card(.spades, .ace), Card(.spades, .king), Card(.spades, .five), Card(.hearts, .two)]
+    let weak = [Card(.clubs, .two), Card(.clubs, .three), Card(.hearts, .ace), Card(.diamonds, .king)]
+    #expect(ComputerPlayer.estimate(strong, suit: .spades) > ComputerPlayer.estimate(weak, suit: .clubs))
+    #expect(ComputerPlayer.estimate(strong, suit: .spades) > ComputerPlayer.estimate(strong, suit: .hearts))
+    #expect(ComputerPlayer.estimate([Card(.hearts, .five), Card(.hearts, .ace)], suit: .hearts)
+            > ComputerPlayer.estimate([Card(.hearts, .five), Card(.clubs, .ace)], suit: .hearts))
+    #expect(ComputerPlayer.estimate([Card(.clubs, .ace)], suit: .hearts) == 0)
+    #expect(ComputerPlayer.decide(view(cards: strong, phase: .bidding, highestBid: 3, bidder: 1)) == .bid(4))
+}
+
+/// Guards the bidding calibration: computers should compete for most hands and usually make their contract.
+@Test func computerBiddingIsCompetitiveAndUsuallyMakesContract() throws {
+    let deck = Suit.allCases.flatMap { suit in Rank.allCases.map { Card(suit, $0) } }
+    var hands = 0, made = 0, forcedDealerTwo = 0
+    for seed in 1...200 {
+        var random = RepeatableRandom(state: UInt64(seed))
+        var match = try Match(deck: deck.shuffled(using: &random), dealer: seed % 4)
+        while match.winner == nil {
+            if match.hand.phase == .finished { try match.startNextHand(deck: deck.shuffled(using: &random)); continue }
+            let seat = try #require(match.hand.nextSeat)
+            try match.apply(try #require(ComputerPlayer.decide(PlayerView(match: match, seat: seat))), seat: seat)
+        }
+        for summary in match.history {
+            hands += 1
+            if summary.result.points[summary.bidder % 2] >= summary.bid { made += 1 }
+            if summary.bid == 2 && summary.bidder == summary.dealer { forcedDealerTwo += 1 }
+        }
+    }
+    #expect(Double(made) / Double(hands) >= 0.7)
+    #expect(Double(forcedDealerTwo) / Double(hands) <= 0.45)
+}

--- a/Tests/CatchFiveUITests/GameModelTests.swift
+++ b/Tests/CatchFiveUITests/GameModelTests.swift
@@ -33,3 +33,18 @@ import Testing
     #expect(restored.hand.auction.highestBid == 2)
     #expect(restored.hand.nextSeat == 1)
 }
+
+@MainActor @Test func modelDescribesAuctionCallsAndContract() throws {
+    let deck = Suit.allCases.flatMap { suit in Rank.allCases.map { Card(suit, $0) } }
+    let model = GameModel(match: try Match(deck: deck, dealer: 3))
+    #expect(model.latestCall(for: 0) == nil)
+    #expect(model.contract == nil)
+    model.send(.bid(nil))
+    #expect(model.latestCall(for: 0) == "Pass")
+    for _ in 0..<3 { model.stepComputer() }
+    #expect(model.match.hand.phase == .choosingTrump)
+    let bidder = try #require(model.match.hand.auction.winner)
+    let bid = try #require(model.match.hand.auction.highestBid)
+    #expect(model.latestCall(for: bidder) == "Bid \(bid)")
+    #expect(model.contract == "\(GameModel.seatNames[bidder]) bid \(bid)")
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,126 @@
+# Architecture
+
+## Three layers, one direction
+
+```mermaid
+flowchart TB
+    subgraph View["View layer — SwiftUI (Sources/CatchFiveUI)"]
+        TV[TableView]
+        CV[CardView]
+        HS[HandSummaryView]
+    end
+    subgraph VM["View model — GameModel (Sources/CatchFiveUI/GameModel.swift)"]
+        GM["GameModel: ObservableObject<br/>owns one Match<br/>send(), stepComputer(), allows(), persist()"]
+    end
+    subgraph Model["Model — rules engine (Sources/CatchFive)"]
+        M[Match] --> H[Hand]
+        H --> AU[Auction]
+        H --> TR[Tricks]
+        H --> SC[Scoring]
+        M --> SC
+        CP[ComputerPlayer] -. reads .-> PV[PlayerView]
+        PV -. built from .-> M
+        MS[MatchSave] -. encodes .-> M
+    end
+    TV --> GM
+    CV --> GM
+    HS --> GM
+    GM --> M
+    GM --> CP
+    GM --> MS
+```
+
+Dependencies only point downward. The engine module imports nothing but the Swift standard library and Foundation. That is not a style preference; it is what lets all 57 tests run on the Mac in under half a second with no simulator.
+
+## MVVM, mapped to this repo
+
+MVVM stands for Model, View, ViewModel. It is the pattern SwiftUI is built around.
+
+| Role | Responsibility | Here | Must not do |
+|---|---|---|---|
+| **Model** | Own the truth and enforce the rules | `Match`, `Hand`, `Auction`, scoring functions | Know about screens, timers, files, or players' intentions |
+| **ViewModel** | Translate between model and view. Hold UI-facing state. Trigger side effects (saving, computer turns). | `GameModel` | Contain game rules. It asks the model "is this legal?" rather than deciding |
+| **View** | Draw the current state. Send user intent to the view model. | `TableView`, `CardView`, `HandSummaryView` | Hold game state, mutate the model directly, or decide legality |
+
+### How a tap becomes a card on the table
+
+```mermaid
+sequenceDiagram
+    actor You
+    participant TV as TableView
+    participant GM as GameModel
+    participant M as Match
+    participant H as Hand
+    participant Disk as MatchSave
+    You->>TV: tap a card
+    TV->>GM: send(.play(card))
+    GM->>GM: guard isHumanTurn
+    GM->>M: apply(.play(card), seat: 0)
+    M->>H: play(seat: 0, card)
+    H->>H: guard phase, turn, ownership, follow-suit
+    H-->>M: mutated copy, or throws
+    M->>M: append to action log; score if hand finished
+    M-->>GM: success or error
+    alt success
+        GM->>Disk: write(match) atomically
+        GM->>GM: revision += 1
+        GM-->>TV: @Published change → re-render
+        TV->>TV: .task(id: revision) schedules the next computer move
+    else error
+        GM-->>TV: errorMessage set → alert
+    end
+```
+
+Two details carry the design:
+
+1. **`allows(_:)` is a dry run.** The view greys out illegal cards by copying the `Match` (cheap, it is a struct) and trying the action on the copy. No legality logic exists in the view.
+2. **`revision` is a heartbeat.** Every accepted action increments it. `TableView` attaches `.task(id: model.revision)`; SwiftUI cancels the old task and starts a new one whenever the id changes. That task sleeps briefly, then calls `stepComputer()` if a computer is due. The chain continues until it is the human's turn or the hand ends. No timers, no queues.
+
+## The referee pattern
+
+Every state-changing method in the engine follows the same shape:
+
+```swift
+public mutating func play(seat: Int, card: Card) throws {
+    guard phase == .playing else { throw HandError.wrongPhase }
+    guard seat == nextSeat else { throw RuleError.outOfTurn }
+    guard let index = hands[seat].firstIndex(of: card) else { throw HandError.cardNotHeld }
+    guard legalMoves(seat: seat).contains(card) else { throw HandError.mustFollowSuit }
+    var updated = self          // work on a copy
+    ...                         // mutate the copy
+    if updated.currentTrick.count == 4 { try updated.finishTrick() }
+    self = updated              // commit only if nothing threw
+}
+```
+
+Validate, copy, mutate the copy, commit. Because `Hand` is a struct, a thrown error in `finishTrick()` leaves `self` untouched. The test `illegalPlayLeavesStateUnchanged` exists to prove this.
+
+## The information boundary
+
+Computer players never see the `Match`. They receive a `PlayerView`: their own cards plus public facts (phase, whose turn, dealer, bids, auction calls, trump, cards on the table). The test `changingHiddenCardsDoesNotChangeComputerDecision` swaps an opponent's hidden card and asserts the computer's decision is identical. The same boundary is what a future online mode would send over the network.
+
+```mermaid
+flowchart LR
+    M["Match (everything)"] -->|"PlayerView(match:seat:)<br/>copies only what seat may know"| PV[PlayerView]
+    PV --> CP["ComputerPlayer.decide"]
+    CP -->|PlayerAction| M
+    M -->|"apply() re-checks legality"| M
+```
+
+The engine does not trust the computer either: its proposed action goes through the same `apply` as a human tap.
+
+## Persistence is a replay log
+
+`MatchSave` does not serialise the board. It stores the initial deck, the initial dealer, and every accepted action. Loading rebuilds the `Match` by replaying those actions through the ordinary rule methods. Consequences:
+
+- A save can never describe an illegal position; replay would throw.
+- A rules bug fixed later changes how old saves replay. That is why the archive carries a `version`.
+- Saves are small and human-readable JSON.
+
+See [decisions.md](decisions.md) for the trade-off discussion.
+
+## Where the Swift 6 concurrency model shows up
+
+- Engine types are `Sendable` structs and enums. They can cross threads freely.
+- `GameModel` is `@MainActor` because it drives UI. Its tests are marked `@MainActor` for the same reason.
+- `TableView`'s `.task` is `async`; `Task.sleep` yields without blocking the main thread, so the UI stays responsive while computers "think".

--- a/docs/build-and-run.md
+++ b/docs/build-and-run.md
@@ -1,0 +1,90 @@
+# Build and Run
+
+## What kind of project this is
+
+Catch 5 is a **Swift package** first and an **iOS app** second. A Swift package is a folder with a `Package.swift` manifest and `Sources/` and `Tests/` directories. The Swift toolchain builds and tests it from the command line with no IDE.
+
+```mermaid
+flowchart LR
+    subgraph Package["Swift package (Package.swift)"]
+        E["Sources/CatchFive<br/>rules engine<br/>(no UI imports)"]
+        U["Sources/CatchFiveUI<br/>GameModel + SwiftUI views"]
+        D["Sources/CatchFiveDemo<br/>terminal demo executable"]
+        T1["Tests/CatchFiveTests"]
+        T2["Tests/CatchFiveUITests"]
+    end
+    A["App/CatchFiveApp.swift<br/>@main entry, 9 lines"]
+    E --> U --> A
+    E --> D
+    E --> T1
+    U --> T2
+```
+
+`Package.swift` declares five targets. Read it as a dependency list: `CatchFiveUI` depends on `CatchFive`, the app depends on `CatchFiveUI`, and nothing depends on the app. The arrows in the diagram only ever point right; the engine never knows a screen exists.
+
+## The four commands
+
+| Command | What it does | When to use |
+|---|---|---|
+| `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test` | Compiles every target and runs all tests (57 as of this page) | After every change |
+| `... swift test --filter <name>` | Runs one test by function name | While working on one rule |
+| `... swift run catch-five-demo` | Plays a fixed five-hand match in the terminal and prints every trick | To watch the engine without the app. Add `--computer` for shuffled computer play, `--save-roundtrip` to see save/restore mid-trick |
+| `... python3 scripts/build-simulator.py` | Produces `work/simulator-build/CatchFive.app` for the iOS simulator | To run the real app |
+
+`DEVELOPER_DIR` points the `swift` command at Xcode's toolchain rather than the command-line-tools copy, which lacks the iOS SDK.
+
+## Why there is a Python build script
+
+Normally `xcodebuild` (or Xcode's Run button) compiles an iOS app. On this Mac the installed Xcode expects an iOS 26.5 platform that is not downloaded, so `xcodebuild` cannot find a destination. The script does the same job by hand.
+
+```mermaid
+flowchart TD
+    S1["xcrun --sdk iphonesimulator --show-sdk-path<br/>find the simulator SDK"] --> S2
+    S2["swiftc -emit-library -static<br/>Sources/CatchFive/*.swift → libCatchFive.a + CatchFive.swiftmodule"] --> S3
+    S3["swiftc -emit-library -static<br/>Sources/CatchFiveUI/*.swift → libCatchFiveUI.a"] --> S4
+    S4["swiftc App/CatchFiveApp.swift -lCatchFiveUI -lCatchFive<br/>→ CatchFive.app/CatchFive executable"] --> S5
+    S5["write Info.plist<br/>bundle id com.cardgame.catchfive, display name Catch 5"] --> S6
+    S6["codesign --sign -<br/>ad-hoc signature the simulator accepts"]
+```
+
+Each `swiftc` call is the compiler invoked directly, with `-target arm64-apple-ios17.0-simulator` so the binary is built for the simulator, and `-swift-version 6`. The `-I` and `-L` flags tell later steps where to find the `.swiftmodule` and `.a` files from earlier steps.
+
+`project.yml` and `CatchFive.xcodeproj` exist for the day Xcode's simulator platform is installed; `xcodegen` regenerates the project from the YAML. They are not used by the script.
+
+## Running on the simulator
+
+The simulator named "Catch 5 iPhone" (UDID `02419047-584C-4D69-A0F1-6F33C2C5F0F2`) is the test device. From the terminal:
+
+```bash
+xcrun simctl install 02419047-584C-4D69-A0F1-6F33C2C5F0F2 work/simulator-build/CatchFive.app
+```
+
+```bash
+xcrun simctl launch 02419047-584C-4D69-A0F1-6F33C2C5F0F2 com.cardgame.catchfive
+```
+
+The app saves to `Application Support/CatchFive/game.json` inside the simulator's container. Reinstalling keeps that file, so a game in progress survives a rebuild.
+
+## What happens at launch
+
+```mermaid
+sequenceDiagram
+    participant iOS
+    participant App as CatchFiveApp (@main)
+    participant GM as GameModel.loadDefault()
+    participant Disk as game.json
+    participant TV as TableView
+    iOS->>App: start process
+    App->>GM: build the model
+    GM->>Disk: does a save exist?
+    alt save exists and replays cleanly
+        Disk-->>GM: Match rebuilt by replaying every action
+    else missing or corrupt
+        GM-->>GM: fresh Match, errorMessage explains if restore failed
+    end
+    App->>TV: TableView(model:)
+    TV-->>iOS: first frame
+    TV->>TV: .task(id: revision) decides if a computer should act
+```
+
+`@main` marks the one type the OS calls to start the app. The whole `App/CatchFiveApp.swift` file is nine lines because all behaviour lives in the package where it can be tested.

--- a/docs/catch-five-rules.md
+++ b/docs/catch-five-rules.md
@@ -14,8 +14,10 @@ Successful normal bidders add every point collected; unsuccessful bidders subtra
 
 A special 9 and out bid is forbidden below zero. At zero or above, collecting all nine points wins the match; collecting fewer loses the match regardless of normal scores.
 
+A 9 and out declaration outranks a normal 9. The dealer may match a 9 and out declaration, and matching overrides it: the dealer becomes the bidder (confirmed 2026-09-04).
+
 ## Pending rare-case clarification
-Whether the dealer can match a special 9 and out declaration, and whether that declaration may overcall a normal 9, are not yet confirmed. The first milestone validates normal auctions and special match settlement separately; it does not silently choose special-auction precedence.
+None outstanding.
 
 ## Delivery
 Approved direction: pure Swift engine and tests first, then offline SwiftUI play with one human and three computer players, save/resume and hand scoring explanations. No multiplayer in the initial playable version.

--- a/docs/code-map.md
+++ b/docs/code-map.md
@@ -42,7 +42,7 @@ A fixed deck makes a failure repeatable. Small rule tests explain exactly which 
 
 ## What Is Not Built Yet
 
-Stronger computer strategy. Baseline heuristic players work and the SwiftUI table in `Sources/CatchFiveUI` (view model tested in `Tests/CatchFiveUITests`) plays full matches with automatic saving. 9-and-out is wired through Match with a provisional precedence rule that still needs house-rule confirmation.
+Stronger computer strategy. Baseline heuristic players work and the SwiftUI table in `Sources/CatchFiveUI` (view model tested in `Tests/CatchFiveUITests`) plays full matches with automatic saving. 9-and-out is wired through Match: it outranks a normal 9 and the dealer may match it to take the bid.
 
 
 ## Following Functions Without Xcode

--- a/docs/code-map.md
+++ b/docs/code-map.md
@@ -19,7 +19,7 @@ The screen sends an action, such as “Seat 0 plays the queen of clubs.” Match
 | Source | Direct tests | Whole-game connection |
 |---|---|---|
 | `Sources/CatchFive/Cards.swift` | `Tests/CatchFiveTests/TrickTests.swift` — cardValuesForGame | Captured values contribute to Game |
-| `Sources/CatchFive/Bidding.swift` | `Tests/CatchFiveTests/BiddingTests.swift` | HandTests verifies winning dealer chooses trump |
+| `Sources/CatchFive/Bidding.swift` | `Tests/CatchFiveTests/BiddingTests.swift` | HandTests verifies winning dealer chooses trump; `calls` feeds the table's per-seat bid display |
 | `Sources/CatchFive/Tricks.swift` | `Tests/CatchFiveTests/TrickTests.swift` | HandTests enforces following suit and next leader |
 | `Sources/CatchFive/Scoring.swift` | `Tests/CatchFiveTests/ScoringTests.swift` | MatchTests checks actual hand and match totals |
 | `Sources/CatchFive/Hand.swift` | `Tests/CatchFiveTests/HandTests.swift` | 208 repeatable hands; no duplicate or missing cards |
@@ -42,7 +42,7 @@ A fixed deck makes a failure repeatable. Small rule tests explain exactly which 
 
 ## What Is Not Built Yet
 
-The SwiftUI screen and stronger computer strategy. Baseline heuristic players now work. Engine save/read APIs exist; automatic app lifecycle saving still needs the UI integration. Normal bidding works end to end. 9-and-out settlement is tested independently; its auction precedence still needs confirmation before connecting it to Match.
+Stronger computer strategy. Baseline heuristic players work and the SwiftUI table in `Sources/CatchFiveUI` (view model tested in `Tests/CatchFiveUITests`) plays full matches with automatic saving. 9-and-out is wired through Match with a provisional precedence rule that still needs house-rule confirmation.
 
 
 ## Following Functions Without Xcode

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -2,7 +2,7 @@
 
 Each entry: what was decided, what it was chosen over, and why. Dates are when the decision landed in the repo. Newest last.
 
-## D1. A dependency-free rules engine (2026-08)
+## D1. A dependency-free rules engine (PR #1, merged 2026-09-04)
 
 **Chosen:** `Sources/CatchFive` imports only the standard library and Foundation. No SwiftUI, no Combine, no packages.
 
@@ -10,7 +10,7 @@ Each entry: what was decided, what it was chosen over, and why. Dates are when t
 
 **Why:** Rules are the part that must be exactly right and change least. Keeping them UI-free means they compile on macOS in the test runner, run 200 matches in under half a second, and can be reused by a terminal demo, a future server, or a different UI without change.
 
-## D2. Value types everywhere in the engine (2026-08)
+## D2. Value types everywhere in the engine (PR #1, merged 2026-09-04)
 
 **Chosen:** `Hand`, `Match`, `Auction` are structs with `private(set)` state and `mutating` methods.
 
@@ -18,7 +18,7 @@ Each entry: what was decided, what it was chosen over, and why. Dates are when t
 
 **Why:** Copying is free and explicit. Validation can work on a copy and commit only on success (`var updated = self … self = updated`), giving transaction semantics without any undo code. `allows(_:)` in the UI is a one-line dry run for the same reason. Structs are also trivially `Sendable`, which Swift 6 strict concurrency demands.
 
-## D3. Throwing validation instead of Bool returns (2026-08)
+## D3. Throwing validation instead of Bool returns (PR #1, merged 2026-09-04)
 
 **Chosen:** Every rule check throws a case of `RuleError`, `HandError`, or `MatchError`.
 
@@ -26,7 +26,7 @@ Each entry: what was decided, what it was chosen over, and why. Dates are when t
 
 **Why:** A thrown error names the rule that was broken, tests can assert the exact case, and the caller cannot forget to check because `try` is mandatory.
 
-## D4. Match settles automatically, redeals explicitly (2026-08)
+## D4. Match settles automatically, redeals explicitly (PR #1, merged 2026-09-04)
 
 **Chosen:** The sixth trick scores and settles the hand inside `Match.play`. Starting the next hand requires a separate `startNextHand(deck:)`.
 
@@ -34,7 +34,7 @@ Each entry: what was decided, what it was chosen over, and why. Dates are when t
 
 **Why:** Scoring twice or forgetting to score are both classic bugs; making it automatic and testing it happens exactly once (`matchScoresOnlyAfterLastCardAndOnlyOnce`) removes them. The explicit redeal exists so the screen can show the hand summary before cards disappear.
 
-## D5. Saves are replay logs, not board snapshots (2026-08)
+## D5. Saves are replay logs, not board snapshots (PR #1, merged 2026-09-04)
 
 **Chosen:** `MatchSave` stores the initial deck, dealer, and every accepted action. Loading replays them through the real rule methods.
 
@@ -42,7 +42,7 @@ Each entry: what was decided, what it was chosen over, and why. Dates are when t
 
 **Why:** A snapshot can describe an impossible position; a replay cannot. It also means no separate decoding validation, tiny files, and human-readable JSON. Cost: replay time grows with match length (fine for a local game) and rule changes alter how old saves replay, hence the `version` field.
 
-## D6. Computers see a `PlayerView`, never the `Match` (2026-08)
+## D6. Computers see a `PlayerView`, never the `Match` (PR #1, merged 2026-09-04)
 
 **Chosen:** `PlayerView(match:seat:)` copies the seat's own cards and public information only.
 
@@ -50,13 +50,13 @@ Each entry: what was decided, what it was chosen over, and why. Dates are when t
 
 **Why:** It makes cheating structurally impossible rather than a matter of discipline, and `changingHiddenCardsDoesNotChangeComputerDecision` proves it. The same shape is what a networked opponent would receive.
 
-## D7. Computer actions go through the same `apply` as humans (2026-08)
+## D7. Computer actions go through the same `apply` as humans (PR #1, merged 2026-09-04)
 
 **Chosen:** `ComputerPlayer.decide` proposes; `Match.apply` checks.
 
 **Why:** A strategy bug can never corrupt a game; it just throws, and the simulation test would fail loudly.
 
-## D8. A revision counter drives the computer scheduler (2026-09)
+## D8. A revision counter drives the computer scheduler (PR #1, merged 2026-09-04)
 
 **Chosen:** `GameModel.revision` increments on every accepted action; `TableView` uses `.task(id: model.revision)` with a short sleep.
 
@@ -64,7 +64,7 @@ Each entry: what was decided, what it was chosen over, and why. Dates are when t
 
 **Why:** SwiftUI cancels and restarts an id-keyed task for free. A human tap bumps the revision, which cancels any sleeping computer task, so ordering bugs cannot occur. The pause between plays is what makes the game readable.
 
-## D9. Build the simulator app with `swiftc` directly (2026-09)
+## D9. Build the simulator app with `swiftc` directly (PR #1, merged 2026-09-04)
 
 **Chosen:** `scripts/build-simulator.py` compiles the modules and assembles the `.app` bundle by hand.
 
@@ -72,13 +72,13 @@ Each entry: what was decided, what it was chosen over, and why. Dates are when t
 
 **Why:** The installed Xcode requires an iOS platform download that is not present, so `xcodebuild` cannot resolve a destination. The script uses the same compiler and SDK and produces a bundle the simulator runs. `project.yml` remains so Xcode can be used when the platform is installed.
 
-## D10. 9-and-out precedence (confirmed 2026-09-04)
+## D10. 9-and-out precedence (PR #2, 2026-09-04)
 
 **Chosen:** A 9-and-out declaration outranks a normal 9. The dealer may match it with their own 9-and-out and thereby takes the bid.
 
-**History:** The engine implemented this behaviour provisionally in August and the docs flagged it as unconfirmed. Connor confirmed the dealer-match rule on 2026-09-04.
+**History:** PR #1 implemented this behaviour provisionally and the docs flagged it as unconfirmed. Connor confirmed the dealer-match rule on 2026-09-04.
 
-## D11. Auction calls are recorded in the engine, not the view (2026-09-04)
+## D11. Auction calls are recorded in the engine, not the view (PR #2, 2026-09-04)
 
 **Chosen:** `Auction.calls` stores each accepted `AuctionCall`; `PlayerView` exposes it; `GameModel` turns it into words.
 
@@ -86,13 +86,13 @@ Each entry: what was decided, what it was chosen over, and why. Dates are when t
 
 **Why:** The engine is the only place that knows which calls were accepted. Storing it there means saves replay it, computers can use it, and the view is stateless. Rejected calls are deliberately not recorded.
 
-## D12. Cards stay readable during bidding (2026-09-04)
+## D12. Cards stay readable during bidding (PR #2, 2026-09-04)
 
 **Chosen:** Hand cards use `allowsHitTesting(playable)` rather than `.disabled(!playable)`.
 
 **Why:** SwiftUI's plain button style dims disabled buttons, which greyed the whole hand while bidding, when reading it matters most. Hit testing switches interaction off without touching appearance; opacity is applied only in the playing phase for illegal cards.
 
-## D13. Bid from an expected-points estimate with a half-point margin (2026-09-04)
+## D13. Bid from an expected-points estimate with a half-point margin (PR #2, 2026-09-04)
 
 **Chosen:** `ComputerPlayer.estimate` sums heuristic weights (High, Low, Jack, Five, control, trump count, refill chance). The bid cap is `floor(estimate − 0.5)`; the computer bids the minimum needed up to that cap.
 
@@ -100,13 +100,13 @@ Each entry: what was decided, what it was chosen over, and why. Dates are when t
 
 **Why:** Measured over 200 seeded matches, the old bidder let two thirds of hands fall to a forced dealer 2. The estimate is calibrated (estimate 5 → 5.6 points made on average). Bidding the full estimate was rejected on economics: in Pitch, being outbid costs about one point relative, while failing a 4 costs roughly nine, so a margin is worth more than aggression. The regression test guards both the competitiveness and the contract rate.
 
-## D14. Keep the trump five off leads (2026-09-04)
+## D14. Keep the trump five off leads (PR #2, 2026-09-04)
 
 **Chosen:** When leading, the computer excludes the trump five unless it is the only legal card.
 
 **Why:** The five is worth more than every other point combined. Leading it hands opponents a free capture with any higher trump. Leading the ace instead draws trumps out while the five stays protected.
 
-## D15. Trick animation keyed by card, not seat (2026-09-04)
+## D15. Trick animation keyed by card, not seat (PR #2, 2026-09-04)
 
 **Chosen:** `ForEach(plays, id: \.card)` with per-seat entry edges and `.animation(value: model.revision)`.
 
@@ -114,7 +114,7 @@ Each entry: what was decided, what it was chosen over, and why. Dates are when t
 
 **Why:** Seat ids repeat every trick, so SwiftUI would treat a new trick as the old views changing content and skip the transition. Cards are unique within a hand, so keying by card makes the old trick leave and the new lead arrive as distinct animations.
 
-## D16. Living documentation in `docs/` (2026-09-04)
+## D16. Living documentation in `docs/` (PR #2, 2026-09-04)
 
 **Chosen:** Flat Markdown pages with Mermaid diagrams, linked from [learning-path.md](learning-path.md), updated in the same commit as the code they describe.
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,0 +1,123 @@
+# Decision Log
+
+Each entry: what was decided, what it was chosen over, and why. Dates are when the decision landed in the repo. Newest last.
+
+## D1. A dependency-free rules engine (2026-08)
+
+**Chosen:** `Sources/CatchFive` imports only the standard library and Foundation. No SwiftUI, no Combine, no packages.
+
+**Over:** Writing rules inside the view model or views, which is the fastest way to get a first screen up.
+
+**Why:** Rules are the part that must be exactly right and change least. Keeping them UI-free means they compile on macOS in the test runner, run 200 matches in under half a second, and can be reused by a terminal demo, a future server, or a different UI without change.
+
+## D2. Value types everywhere in the engine (2026-08)
+
+**Chosen:** `Hand`, `Match`, `Auction` are structs with `private(set)` state and `mutating` methods.
+
+**Over:** Classes with mutable properties.
+
+**Why:** Copying is free and explicit. Validation can work on a copy and commit only on success (`var updated = self … self = updated`), giving transaction semantics without any undo code. `allows(_:)` in the UI is a one-line dry run for the same reason. Structs are also trivially `Sendable`, which Swift 6 strict concurrency demands.
+
+## D3. Throwing validation instead of Bool returns (2026-08)
+
+**Chosen:** Every rule check throws a case of `RuleError`, `HandError`, or `MatchError`.
+
+**Over:** Returning `false` or an optional.
+
+**Why:** A thrown error names the rule that was broken, tests can assert the exact case, and the caller cannot forget to check because `try` is mandatory.
+
+## D4. Match settles automatically, redeals explicitly (2026-08)
+
+**Chosen:** The sixth trick scores and settles the hand inside `Match.play`. Starting the next hand requires a separate `startNextHand(deck:)`.
+
+**Over:** Auto-dealing the next hand, or requiring a separate "score" call.
+
+**Why:** Scoring twice or forgetting to score are both classic bugs; making it automatic and testing it happens exactly once (`matchScoresOnlyAfterLastCardAndOnlyOnce`) removes them. The explicit redeal exists so the screen can show the hand summary before cards disappear.
+
+## D5. Saves are replay logs, not board snapshots (2026-08)
+
+**Chosen:** `MatchSave` stores the initial deck, dealer, and every accepted action. Loading replays them through the real rule methods.
+
+**Over:** Encoding every property of `Match` and `Hand`.
+
+**Why:** A snapshot can describe an impossible position; a replay cannot. It also means no separate decoding validation, tiny files, and human-readable JSON. Cost: replay time grows with match length (fine for a local game) and rule changes alter how old saves replay, hence the `version` field.
+
+## D6. Computers see a `PlayerView`, never the `Match` (2026-08)
+
+**Chosen:** `PlayerView(match:seat:)` copies the seat's own cards and public information only.
+
+**Over:** Passing the whole `Match` to the strategy for convenience.
+
+**Why:** It makes cheating structurally impossible rather than a matter of discipline, and `changingHiddenCardsDoesNotChangeComputerDecision` proves it. The same shape is what a networked opponent would receive.
+
+## D7. Computer actions go through the same `apply` as humans (2026-08)
+
+**Chosen:** `ComputerPlayer.decide` proposes; `Match.apply` checks.
+
+**Why:** A strategy bug can never corrupt a game; it just throws, and the simulation test would fail loudly.
+
+## D8. A revision counter drives the computer scheduler (2026-09)
+
+**Chosen:** `GameModel.revision` increments on every accepted action; `TableView` uses `.task(id: model.revision)` with a short sleep.
+
+**Over:** A `Timer`, a Combine pipeline, or a loop that plays all computer moves at once.
+
+**Why:** SwiftUI cancels and restarts an id-keyed task for free. A human tap bumps the revision, which cancels any sleeping computer task, so ordering bugs cannot occur. The pause between plays is what makes the game readable.
+
+## D9. Build the simulator app with `swiftc` directly (2026-09)
+
+**Chosen:** `scripts/build-simulator.py` compiles the modules and assembles the `.app` bundle by hand.
+
+**Over:** `xcodebuild`, which is the normal route.
+
+**Why:** The installed Xcode requires an iOS platform download that is not present, so `xcodebuild` cannot resolve a destination. The script uses the same compiler and SDK and produces a bundle the simulator runs. `project.yml` remains so Xcode can be used when the platform is installed.
+
+## D10. 9-and-out precedence (confirmed 2026-09-04)
+
+**Chosen:** A 9-and-out declaration outranks a normal 9. The dealer may match it with their own 9-and-out and thereby takes the bid.
+
+**History:** The engine implemented this behaviour provisionally in August and the docs flagged it as unconfirmed. Connor confirmed the dealer-match rule on 2026-09-04.
+
+## D11. Auction calls are recorded in the engine, not the view (2026-09-04)
+
+**Chosen:** `Auction.calls` stores each accepted `AuctionCall`; `PlayerView` exposes it; `GameModel` turns it into words.
+
+**Over:** Having `TableView` remember what it saw as bids went by.
+
+**Why:** The engine is the only place that knows which calls were accepted. Storing it there means saves replay it, computers can use it, and the view is stateless. Rejected calls are deliberately not recorded.
+
+## D12. Cards stay readable during bidding (2026-09-04)
+
+**Chosen:** Hand cards use `allowsHitTesting(playable)` rather than `.disabled(!playable)`.
+
+**Why:** SwiftUI's plain button style dims disabled buttons, which greyed the whole hand while bidding, when reading it matters most. Hit testing switches interaction off without touching appearance; opacity is applied only in the playing phase for illegal cards.
+
+## D13. Bid from an expected-points estimate with a half-point margin (2026-09-04)
+
+**Chosen:** `ComputerPlayer.estimate` sums heuristic weights (High, Low, Jack, Five, control, trump count, refill chance). The bid cap is `floor(estimate − 0.5)`; the computer bids the minimum needed up to that cap.
+
+**Over:** The previous flat "2 per trump, +2 for honours" count capped at 5, and an alternative of bidding the full estimate.
+
+**Why:** Measured over 200 seeded matches, the old bidder let two thirds of hands fall to a forced dealer 2. The estimate is calibrated (estimate 5 → 5.6 points made on average). Bidding the full estimate was rejected on economics: in Pitch, being outbid costs about one point relative, while failing a 4 costs roughly nine, so a margin is worth more than aggression. The regression test guards both the competitiveness and the contract rate.
+
+## D14. Keep the trump five off leads (2026-09-04)
+
+**Chosen:** When leading, the computer excludes the trump five unless it is the only legal card.
+
+**Why:** The five is worth more than every other point combined. Leading it hands opponents a free capture with any higher trump. Leading the ace instead draws trumps out while the five stays protected.
+
+## D15. Trick animation keyed by card, not seat (2026-09-04)
+
+**Chosen:** `ForEach(plays, id: \.card)` with per-seat entry edges and `.animation(value: model.revision)`.
+
+**Over:** Keying by seat.
+
+**Why:** Seat ids repeat every trick, so SwiftUI would treat a new trick as the old views changing content and skip the transition. Cards are unique within a hand, so keying by card makes the old trick leave and the new lead arrive as distinct animations.
+
+## D16. Living documentation in `docs/` (2026-09-04)
+
+**Chosen:** Flat Markdown pages with Mermaid diagrams, linked from [learning-path.md](learning-path.md), updated in the same commit as the code they describe.
+
+**Over:** Relying on an IDE's navigation, or generated API docs.
+
+**Why:** Connor reads the code without an IDE. Diagrams render on GitHub, plain Markdown reads anywhere, and the "same commit" rule keeps pages from rotting.

--- a/docs/game-flow.md
+++ b/docs/game-flow.md
@@ -1,0 +1,114 @@
+# Game Flow
+
+Seats are 0 (You), 1 (West), 2 (Partner), 3 (East). Team 0 is seats 0 and 2; team 1 is seats 1 and 3. Play moves in ascending seat order, wrapping at 4.
+
+## A match
+
+```mermaid
+stateDiagram-v2
+    [*] --> Hand1: Match(deck:dealer:)
+    Hand1 --> Settled: sixth trick scored once
+    Settled --> NextHand: startNextHand(deck:)<br/>dealer rotates +1
+    NextHand --> Settled: sixth trick scored
+    Settled --> [*]: a team reaches 25<br/>or 9-and-out resolves
+```
+
+`Match.winner` becomes non-nil exactly once. After that every action throws `MatchError.matchFinished`. The screen asks for an explicit "Deal next hand" tap so the scoring breakdown can be read first.
+
+## One hand: the four phases
+
+```mermaid
+stateDiagram-v2
+    [*] --> bidding: deal 6 each,<br/>two packets of 3,<br/>left of dealer first
+    bidding --> choosingTrump: dealer has acted<br/>(auction.nextSeat == nil)
+    choosingTrump --> playing: bid winner names trump;<br/>everyone discards non-trumps<br/>and refills to 6
+    playing --> playing: card played;<br/>4th card resolves the trick,<br/>winner leads
+    playing --> finished: 6th trick →<br/>scoreHand → Match.recordHand
+    finished --> [*]
+```
+
+`HandPhase` is the enum with these four cases. Every `Hand` method starts with a guard on `phase`, so calling `play` during `bidding` throws `HandError.wrongPhase` rather than doing something odd.
+
+## The auction, turn by turn
+
+```mermaid
+flowchart TD
+    A["nextSeat = dealer + 1"] --> B{"Is this seat the dealer?"}
+    B -- no --> C{"Pass?"}
+    C -- yes --> D["record AuctionCall(seat, nil)"]
+    C -- no --> E{"bid ≥ highest + 1<br/>and 2…9?"}
+    E -- no --> X["throw invalidBid<br/>turn is NOT consumed"]
+    E -- yes --> F["highestBid = bid, winner = seat<br/>record AuctionCall"]
+    D --> G["nextSeat += 1"]
+    F --> G
+    G --> B
+    B -- yes --> H{"Anyone bid?"}
+    H -- no --> I["dealer must bid 2<br/>(pass throws)"]
+    H -- yes --> J["dealer may match highest,<br/>raise, or pass"]
+    I --> K["nextSeat = nil<br/>phase → choosingTrump"]
+    J --> K
+```
+
+Special bid: `nineAndOut` sets `highestBid = 9` and `isNineAndOut = true`. It outranks a normal 9. Only the dealer may bid against it, and only by matching with their own 9-and-out; that override was confirmed as a house rule on 2026-09-04. Normal bids after a 9-and-out throw.
+
+`Auction.calls` is the ordered list of accepted calls. The table reads it to show "Bid 3" or "Pass" under each seat; computers receive it in `PlayerView.calls`.
+
+## One trick
+
+```mermaid
+sequenceDiagram
+    participant L as Leader
+    participant H as Hand
+    participant N as Next three seats
+    L->>H: play(card) — any card is legal on a lead
+    loop three more plays
+        N->>H: play(card)
+        H->>H: legalMoves: must follow led suit if able,<br/>otherwise anything (trumping allowed)
+    end
+    H->>H: trickWinner: highest trump if any trump was played,<br/>else highest card of the led suit
+    H->>H: captured[winner % 2] += all four cards
+    H->>H: nextSeat = winner
+    Note over H: on the 6th trick: scoreHand, phase = finished
+```
+
+The screen keeps the last completed trick visible, ringed in gold on the winning card, until the winner leads the next card. Then the old trick fades and the new lead slides in from that seat's edge of the table.
+
+## Scoring at the end of a hand
+
+```mermaid
+flowchart LR
+    C["captured cards<br/>per team"] --> HI["High: highest trump played → 1"]
+    C --> LO["Low: lowest trump played → 1"]
+    C --> J["Jack of trump, if played → 1"]
+    C --> F["Five of trump, if played → 5"]
+    C --> G["Game: 10=10 J=1 Q=2 K=3 A=4<br/>across all suits → 1<br/>tie → bidding team"]
+    HI & LO & J & F & G --> P["HandScore.points [team0, team1]"]
+    P --> S["settle(scores, points, bidder, bid)"]
+    S --> R{"bidder made bid?"}
+    R -- yes --> Y["bidder += its points"]
+    R -- no --> N["bidder −= bid amount"]
+    Y & N --> DEF["defenders += their points"]
+    DEF --> W{"≥ 25?"}
+```
+
+High and Low are relative to cards actually played. Undealt cards stay in the stock and never count, which is why "Out of play" can appear for Jack or Five in the hand summary.
+
+## Who acts when: the screen's scheduler
+
+```mermaid
+flowchart TD
+    R["model.revision changed"] --> T[".task(id: revision) starts"]
+    T --> Q{"human's turn,<br/>or hand/match over?"}
+    Q -- yes --> STOP["do nothing; wait for a tap"]
+    Q -- no --> S["sleep 1.2 s if leading a trick,<br/>0.7 s otherwise"]
+    S --> C{"task cancelled?<br/>(revision changed again)"}
+    C -- yes --> STOP
+    C -- no --> D["stepComputer():<br/>PlayerView → ComputerPlayer.decide → match.apply"]
+    D --> R
+```
+
+Because `stepComputer()` increments `revision`, the next task starts automatically. The human's tap also increments it, which cancels any pending computer sleep, so nothing acts out of turn.
+
+## Saving
+
+Every accepted action calls `persist()`, and `TableView` also calls it whenever the app leaves the foreground (`scenePhase` change). The write is atomic: the old file is replaced only when the new one is complete. `loadDefault()` reads it at launch; on failure the user sees an explanation and a fresh game.

--- a/docs/learning-path.md
+++ b/docs/learning-path.md
@@ -1,0 +1,53 @@
+# Learning Path: Reading Catch 5 Without an IDE
+
+This is the front door to the living documentation. Each linked page is kept in step with the code; when a source file changes, the page that explains it changes in the same commit.
+
+## Reading order
+
+| Step | Page | What you will understand afterwards |
+|---|---|---|
+| 1 | [build-and-run.md](build-and-run.md) | What a Swift package is, what the four commands you actually run do, and how the simulator build works without Xcode's editor |
+| 2 | [architecture.md](architecture.md) | The three layers (engine, view model, SwiftUI), why the engine has no UI code, and how MVVM maps onto this repo |
+| 3 | [game-flow.md](game-flow.md) | The state machines: one hand, one auction, one trick, one match, and how the screen turns computer players on and off |
+| 4 | [types-and-functions.md](types-and-functions.md) | Every type and public function, one line each, with the test that proves it |
+| 5 | [testing.md](testing.md) | How Swift Testing works, the test pyramid here, and how each feature was built test-first |
+| 6 | [decisions.md](decisions.md) | The decision log: what was chosen, what was rejected, and why |
+| 7 | [code-map.md](code-map.md) | Older call-trace walkthroughs (match scoring, save/resume, computer path); still accurate |
+
+## Swift vocabulary used in these pages
+
+You will meet these words constantly. Each is defined once here and used without explanation elsewhere.
+
+| Term | Meaning in plain words | Where you see it |
+|---|---|---|
+| `struct` | A value type. Assigning it makes an independent copy. Changing a copy never changes the original. | `Card`, `Hand`, `Match`, `Auction` |
+| `class` | A reference type. Two variables can point at the same object. Used only where SwiftUI needs a shared, observable object. | `GameModel` |
+| `enum` | A fixed set of cases. Cases may carry data ("associated values"). | `Suit`, `HandPhase`, `PlayerAction.play(Card)` |
+| `mutating func` | A method on a struct that changes the struct it is called on. | `Hand.play`, `Match.bid` |
+| `private(set) var` | Anyone can read it, only the owning type can change it. This is how the engine stays a referee. | Most `Hand` and `Match` properties |
+| `throws` / `try` | The function can fail with a typed error instead of returning garbage. Callers must write `try`. | Every rule check |
+| `guard ... else { throw }` | Validate first, exit early. The rest of the function runs only when the guard passes. | Everywhere in the engine |
+| `Sendable` | The compiler checks this value is safe to pass between threads. All engine types are `Sendable`. | Type declarations |
+| `Codable` | Can be converted to and from JSON automatically. | `Card`, `SavedAction` |
+| `@MainActor` | Runs only on the main thread, which is where UI must be updated. | `GameModel`, view model tests |
+| `ObservableObject` / `@Published` | A class SwiftUI watches. When a `@Published` property changes, dependent views re-render. | `GameModel` |
+| `@StateObject` | A view owns this observable object for its lifetime. | `TableView` |
+| `some View` | "Returns a view; the exact type is the compiler's business." | Every SwiftUI `body` |
+| `@Test` / `#expect` | Swift Testing attributes. `@Test` marks a test function; `#expect` records a failure without stopping. | All tests |
+| `#require` | Like `#expect` but stops the test if the value is missing. Used to unwrap optionals safely. | Simulation tests |
+
+## How to read a Swift file in a plain editor
+
+1. Skim the type declarations first (`struct`, `enum`, `class`). Note which properties are `private(set)`; those are the state the type protects.
+2. Read the `init`. It tells you what the type needs to exist and what it validates on creation.
+3. Read each `mutating func` top to bottom: guards first, then the change, then any follow-on effects such as `finishTrick()`.
+4. Open the matching test file in [types-and-functions.md](types-and-functions.md). Each test name is a sentence describing a rule.
+5. Run just that test:
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter playMustFollowSuitAndWinningPlayerLeadsNext
+```
+
+## Keeping these pages live
+
+Rule for every future change: if a commit adds or renames a type, function, phase, or test, the same commit updates the relevant page here. `CLAUDE.md` states this so automated sessions follow it too.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,105 @@
+# Testing
+
+## Swift Testing in one minute
+
+The repo uses Apple's `Testing` framework (not the older XCTest). A test is a free function:
+
+```swift
+import Testing
+@testable import CatchFive   // @testable exposes internal names
+
+@Test func dealerMustTakeTwoAfterPasses() throws {
+    var auction = try Auction(dealer: 3)
+    for seat in 0..<3 { try auction.act(seat: seat, bid: nil) }
+    #expect(throws: RuleError.invalidBid) { try auction.act(seat: 3, bid: nil) }
+    try auction.act(seat: 3, bid: 2)
+    #expect(auction.winner == 3)
+}
+```
+
+- `@Test` registers the function. The name is the specification; read it as a sentence.
+- `#expect(condition)` records a failure and keeps going, so one run reports every broken assertion.
+- `#expect(throws:)` asserts that a specific error is thrown.
+- `try #require(optional)` unwraps or fails the test immediately; it replaces force-unwrapping.
+- `@MainActor @Test` is needed for tests that touch `GameModel`.
+
+Run everything, or one test:
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
+```
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter computerBidding
+```
+
+`--filter` matches a substring of the test name.
+
+## The pyramid here
+
+```mermaid
+flowchart BT
+    L1["Rule primitives (19 tests)<br/>TrickTests, BiddingTests, ScoringTests<br/>fixed cards, one rule each, milliseconds"]
+    L2["Hand lifecycle (7 tests)<br/>HandTests<br/>208 deterministic complete hands, card conservation after every move"]
+    L3["Match coordinator (8 tests)<br/>MatchTests<br/>five-hand fixture with hand-checked scores 2–7, 10–5, 12–12, 19–14, 26–16"]
+    L4["Persistence (7 tests)<br/>SaveTests<br/>resume in every phase, corrupt files, disk errors"]
+    L5["Computer players (13 tests)<br/>ComputerPlayerTests<br/>single decisions + 24 shuffled matches + 200-match bidding calibration"]
+    L6["View model (3 tests)<br/>GameModelTests<br/>human/computer handoff, save on success, error on illegal move"]
+    L7["Manual: simulator<br/>screenshots of bidding, trump choice, play, hand summary"]
+    L1 --> L2 --> L3 --> L4 --> L5 --> L6 --> L7
+```
+
+Total: 57 automated tests, about 0.4 s. Every layer above the first uses the real code beneath it; nothing is mocked. If `trickWinner` broke, the failure would show up in one small trick test *and* in the 208-hand simulation, and the small one tells you exactly what changed.
+
+## Two kinds of test, deliberately
+
+| Kind | Example | Purpose |
+|---|---|---|
+| **Example-based** | `computerFeedsFiveToPartnerWhenLastToPlay` builds a three-card trick and asserts the exact card played | Explain one rule to a reader; pinpoint a regression |
+| **Simulation / property** | `completeHandsConserveCardsAndFinishAfterSixTricks` plays 208 hands (every dealer × every trump × many decks) and asserts the 52 cards are always accounted for | Catch interactions no example anticipated |
+
+The seeded random generator `RepeatableRandom` (a linear congruential generator in `ComputerPlayerTests`) makes the shuffled simulations reproducible: the same seed always yields the same deck order, so a failure can be re-run.
+
+## How a feature was built test-first
+
+The auction call history added on 2026-09-04 followed the cycle every earlier milestone used:
+
+```mermaid
+sequenceDiagram
+    participant T as Test file
+    participant C as Compiler
+    participant S as Source
+    T->>C: add auctionRecordsEverySeatCallInOrder using AuctionCall and auction.calls
+    C-->>T: error: cannot find 'AuctionCall' in scope
+    Note over T,C: red — the test describes the API before it exists
+    S->>C: add AuctionCall struct, calls array, append inside act()
+    C-->>T: 54 tests pass
+    Note over S: green — smallest change that satisfies the test
+    S->>S: expose calls on PlayerView, add UI wording in GameModel
+    T->>C: add computerSeesPublicAuctionCalls and modelDescribesAuctionCallsAndContract
+    C-->>T: 55 tests pass
+```
+
+The compile error *is* the first failing test. Only then does the implementation start.
+
+## Calibration tests
+
+`computerBiddingIsCompetitiveAndUsuallyMakesContract` is different from the others: it asserts statistics, not exact values. Over 200 seeded matches it requires that bidders make their contract at least 70% of the time and that no more than 45% of hands end as a forced dealer 2. Those thresholds sit below the measured figures (about 78% and 33%) so normal tuning passes, but a change that makes the computers reckless or timid fails.
+
+The numbers came from a throwaway harness that printed, for each estimated-points bucket, the average points actually made. The table it produced (estimate 4 → 4.85 average, 5 → 5.6, 6 → 6.4) is what justified using the estimate as a bid cap. See [decisions.md](decisions.md).
+
+## What is not automated
+
+- Visual layout and animation. Checked by building with `scripts/build-simulator.py`, launching on the "Catch 5 iPhone" simulator and taking screenshots at each phase.
+- Save/restore across app relaunch. Verified manually by killing and relaunching the app mid-trick; the engine side of the same path is covered by `SaveTests`.
+
+## Reading a failure
+
+Swift Testing prints the file, line, and the expression with its actual values:
+
+```
+✘ Test computerRaisesWithStrongSuitAndChoosesIt() recorded an issue at ComputerPlayerTests.swift:22:5:
+  Expectation failed: (ComputerPlayer.decide(...) → .bid(3)) == (.bid(4))
+```
+
+The left side is what the code did, the right side what the test expected. Open the test by name in [types-and-functions.md](types-and-functions.md) to find which source function it guards.

--- a/docs/types-and-functions.md
+++ b/docs/types-and-functions.md
@@ -1,0 +1,196 @@
+# Types and Functions
+
+One line per public thing, grouped by file, with the test that proves it. Names are exact so you can `grep` for them.
+
+## Class diagram
+
+```mermaid
+classDiagram
+    class Card {
+        +Suit suit
+        +Rank rank
+    }
+    class Auction {
+        +Int dealer
+        +Int? nextSeat
+        +Int? winner
+        +Int? highestBid
+        +Bool isNineAndOut
+        +[AuctionCall] calls
+        +act(seat, bid, nineAndOut)
+    }
+    class AuctionCall {
+        +Int seat
+        +Bid? bid
+    }
+    class Hand {
+        +HandPhase phase
+        +Auction auction
+        +[[Card]] hands
+        +[Card] stock
+        +[Card] discarded
+        +Suit? trump
+        +Int? nextSeat
+        +[Play] currentTrick
+        +[CompletedTrick] completedTricks
+        +[[Card]] captured
+        +HandScore? result
+        +bid(seat, amount, nineAndOut)
+        +chooseTrump(seat, suit)
+        +play(seat, card)
+        +legalMoves(seat)
+    }
+    class Match {
+        +Hand hand
+        +[Int] scores
+        +Int? winner
+        +[HandSummary] history
+        +Int handNumber
+        +bid() bidNineAndOut() chooseTrump() play()
+        +startNextHand(deck)
+        +apply(PlayerAction, seat)
+    }
+    class PlayerView {
+        +Int seat
+        +[Card] cards
+        +public facts…
+    }
+    class ComputerPlayer {
+        +decide(PlayerView) PlayerAction?
+        +estimate(cards, suit) Double
+    }
+    class MatchSave {
+        +encode(Match) Data
+        +decode(Data) Match
+        +write(Match, to URL)
+        +read(from URL) Match
+    }
+    class GameModel {
+        +Match match
+        +Int revision
+        +String? errorMessage
+        +send(PlayerAction)
+        +stepComputer()
+        +allows(PlayerAction) Bool
+        +latestCall(for seat) String?
+        +contract String?
+        +persist()
+    }
+    Hand *-- Auction
+    Auction *-- AuctionCall
+    Match *-- Hand
+    Match --> HandSummary
+    Hand --> Card
+    PlayerView ..> Match : built from
+    ComputerPlayer ..> PlayerView
+    MatchSave ..> Match
+    GameModel *-- Match
+    GameModel ..> ComputerPlayer
+    GameModel ..> MatchSave
+```
+
+## Sources/CatchFive/Cards.swift
+
+| Name | Kind | Purpose | Proven by |
+|---|---|---|---|
+| `Suit` | enum, `CaseIterable` | clubs, diamonds, hearts, spades | used everywhere |
+| `Rank` | enum, `Int` raw values 2…14 | two … ace; `rawValue` orders cards | `highestTrumpWins` |
+| `Rank.gameValue` | computed property | 10→10, J→1, Q→2, K→3, A→4, else 0 | `cardValuesForGame` |
+| `Card` | struct, `Hashable`, `Codable` | one suit and one rank | everywhere |
+| `RuleError` | enum | invalidTrick, invalidSeat, outOfTurn, invalidBid, auctionComplete, invalidScoring, forbiddenNineAndOut | error assertions across suites |
+
+## Sources/CatchFive/Tricks.swift
+
+| Name | Purpose | Proven by |
+|---|---|---|
+| `Play` | one seat's card in a trick | trick tests |
+| `legalCards(in:led:)` | if you hold the led suit you must play it; otherwise anything | `mustFollowSuitEvenWithTrump` |
+| `trickWinner(_:trump:)` | highest trump, else highest of led suit; rejects malformed tricks | `trumpBeatsLedAce`, `highestTrumpWins`, `malformedTricksAreRejected` |
+
+## Sources/CatchFive/Bidding.swift
+
+| Name | Purpose | Proven by |
+|---|---|---|
+| `Bid` | `.points(Int)` or `.nineAndOut` | settlement tests |
+| `AuctionCall` | one seat's accepted call; `bid == nil` is a pass | `auctionRecordsEverySeatCallInOrder` |
+| `Auction` | four-turn bidding round starting left of dealer | all `BiddingTests` |
+| `Auction.act(seat:bid:nineAndOut:)` | validates turn, minimum raise, dealer match, forced 2, 9-and-out precedence; records the call | `dealerCanMatchPartnerOrOpponent`, `nonDealerMustRaiseAndInvalidActionDoesNotConsumeTurn`, `dealerMustTakeTwoAfterPasses`, `bidRangeAndTurnOrder`, `nineAndOutOvercallsNineAndDealerCanMatch` |
+
+## Sources/CatchFive/Scoring.swift
+
+| Name | Purpose | Proven by |
+|---|---|---|
+| `HandScore` | points per team plus which team took High, Low, Jack, Five, Game and the Game values | scoring tests |
+| `scoreHand(captured:trump:bidder:)` | pure function from captured cards to `HandScore`; rejects duplicate cards | `relativeHighAndLowBelongToCapturingTeams`, `missingJackAndFiveDoNotScoreAndGameTieGoesToBidder`, `offSuitScoringCardsOnlyCountTowardGame`, `invalidCapturedCardsAreRejected` |
+| `Settlement` | new scores and optional winner | |
+| `settle(scores:points:bidder:bid:)` | bidder adds points or subtracts bid; defenders add; 25 wins; 9-and-out ends the match either way | `successfulBidScoresAllPointsAndSetLosesBidAmount`, `twentyFiveAndSimultaneousFinish`, `nineAndOutWinsOrLosesImmediately`, `invalidSettlementRejected` |
+
+## Sources/CatchFive/Hand.swift
+
+| Name | Purpose | Proven by |
+|---|---|---|
+| `HandPhase` | bidding, choosingTrump, playing, finished | phase guards in every test |
+| `CompletedTrick` | four plays and the winning seat | `playMustFollowSuitAndWinningPlayerLeadsNext` |
+| `HandError` | invalidDeck, wrongPhase, notBidWinner, cardNotHeld, mustFollowSuit | |
+| `Hand.init(deck:dealer:)` | requires 52 unique cards; deals two packets of three | `dealSixEachInTwoPacketsStartingLeftOfDealer`, `rejectInvalidDecks` |
+| `Hand.bid` | forwards to `Auction`; moves to `choosingTrump` when the dealer has acted | `trumpSelectionRequiresFinishedAuctionAndWinningSeat` |
+| `Hand.chooseTrump` | bid winner only; discards non-trumps, refills to six from stock | `refillKeepsTrumpsAndDiscardsOnlyInitialNonTrumps` |
+| `Hand.play` | full validation, copy-mutate-commit; fourth card resolves the trick, sixth trick scores | `illegalPlayLeavesStateUnchanged`, `completeHandsConserveCardsAndFinishAfterSixTricks` (208 hands) |
+| `Hand.legalMoves(seat:)` | empty unless it is that seat's turn in `playing` | UI greying relies on this through `allows` |
+
+## Sources/CatchFive/Match.swift
+
+| Name | Purpose | Proven by |
+|---|---|---|
+| `MatchError` | handInProgress, matchFinished | `matchRejectsPrematureRedeal` |
+| `HandSummary` | number, dealer, bidder, bid, isNineAndOut, result, running scores | `nextHandRotatesDealerAndRetainsScores` |
+| `Match.init(deck:dealer:)` | starts hand 1 and remembers the deck for saves | |
+| `Match.bid` / `bidNineAndOut` / `chooseTrump` / `play` | wrap `Hand`, refuse after a winner, append to the action log; `play` settles the hand exactly once | `matchScoresOnlyAfterLastCardAndOnlyOnce`, `failedBidMakesNegativeMatchScore`, `negativeTeamCannotDeclareNineAndOut` |
+| `Match.startNextHand(deck:)` | only after `finished`; dealer + 1 | `nextHandRotatesDealerAndRetainsScores` |
+| `Match.apply(_:seat:)` | one entry point for `PlayerAction` from humans and computers | `computersCompleteShuffledMatchesThroughRealRules` |
+
+## Sources/CatchFive/ComputerPlayer.swift
+
+| Name | Purpose | Proven by |
+|---|---|---|
+| `PlayerView` | own cards plus public facts; `init(match:seat:)` copies only what the seat may know | `changingHiddenCardsDoesNotChangeComputerDecision`, `computerSeesPublicAuctionCalls` |
+| `PlayerAction` | nineAndOut, bid(Int?), chooseTrump(Suit), play(Card) | |
+| `ComputerPlayer.decide(_:)` | returns nil unless it is this seat's turn | `computerDoesNotActOutsideItsTurn` |
+| `ComputerPlayer.estimate(_:suit:)` | expected hand points if that suit were trump | `estimateRanksControlAndTheFiveAboveScatteredCards` |
+| bidding (private `bidAmount`) | bid the minimum needed if it is at most estimate − 0.5; never outbid partner; dealer takes forced 2 | `computerPassesWeakHandButDealerTakesForcedTwo`, `computerRaisesWithStrongSuitAndChoosesIt`, `computerBiddingIsCompetitiveAndUsuallyMakesContract` |
+| card play (private `chooseCard`) | lead highest trump but not the five; cheapest winner against opponents; feed points to a winning partner when last; otherwise dump the least valuable | `computerFollowsSuitInsteadOfTrumping`, `computerUsesLowestWinningCardAgainstOpponent`, `computerFeedsFiveToPartnerWhenLastToPlay`, `computerPreservesFiveWhenItCannotWin`, `computerLeadsHighestTrumpButKeepsTheFiveBack` |
+
+## Sources/CatchFive/MatchSave.swift
+
+| Name | Purpose | Proven by |
+|---|---|---|
+| `SaveError` | invalidData, unsupportedVersion | `rejectsBrokenOrUnsupportedSave` |
+| `SavedAction` (internal) | Codable mirror of the five actions, each replays through the real `Match` method | `replayRejectsIllegalActionsAndInvalidInitialDeck` |
+| `MatchSave.encode` / `decode` | version 1 JSON: initial deck, dealer, actions | `saveRestoresEveryPhaseAndContinuesIdentically`, `saveRestoresHistoryAndNextDealer`, `rejectedActionsNeverEnterSaveAndResavingDoesNotDuplicateActions` |
+| `MatchSave.write` / `read` | atomic file replacement; errors surface | `saveRoundTripOnDiskReplacesPreviousSave`, `diskFailuresAreReported` |
+
+## Sources/CatchFiveUI/GameModel.swift
+
+| Name | Purpose | Proven by |
+|---|---|---|
+| `GameModel` | `@MainActor ObservableObject` owning one `Match`, a `revision` counter, an optional `errorMessage`, and an optional save URL | |
+| `isHumanTurn`, `humanCards` | convenience for seat 0 | `humanActionAdvancesComputersAndStopsForHuman` |
+| `send(_:)` | human action through `Match.apply`, then persist and bump revision | `acceptedHumanMoveSavesAndInvalidMoveShowsError` |
+| `stepComputer()` | one computer action for whichever non-human seat is due | `humanActionAdvancesComputersAndStopsForHuman` |
+| `allows(_:)` | dry run on a copy of the match | drives button enabling |
+| `latestCall(for:)`, `contract`, `seatNames` | wording for the auction display | `modelDescribesAuctionCallsAndContract` |
+| `nextHand()`, `newGame()` | fresh shuffled deck via `deck()` | |
+| `persist()`, `loadDefault()` | Application Support/CatchFive/game.json | manual simulator check |
+
+## Sources/CatchFiveUI views
+
+| Name | Purpose |
+|---|---|
+| `TableView` | the whole screen: header, scores and contract, three opponent tiles, status line, trick area, hand, phase-specific controls, new-game confirmation, error alert, computer scheduler task, background save |
+| `CardView` | a 48×72 card face with accessibility label; `Suit.glyph`, `Suit.ink`, `Card.label` helpers |
+| `HandSummaryView` | who took High, Low, Jack, Five, Game for the last hand and what was bid |
+| colour extensions | `.ivory`, `.felt`, `.gold` |
+
+## Sources/CatchFiveDemo
+
+`main.swift` plays a fixed, deterministic match (`swift run catch-five-demo`) and `ComputerDemo.swift` a shuffled computer match (`--computer`). Both call the real `Match`; they contain no rules of their own.


### PR DESCRIPTION
## Summary
- **Auction display:** `Auction` records every accepted call per seat (`AuctionCall`); `PlayerView` exposes it. The table shows each opponent's latest call while bidding, marks the bidder afterwards, and keeps the contract ("West bid 4") in the score bar for the rest of the hand. The human's hand is no longer greyed out during bidding.
- **House rule confirmed:** 9-and-out outranks a normal 9 and the dealer may match it to take the bid. Documented in `docs/catch-five-rules.md`.
- **Computer bidding:** replaces the flat suit count with `ComputerPlayer.estimate`, an expected-points estimate per suit; bids the minimum needed up to estimate − 0.5. Over 200 seeded matches forced dealer twos drop from 67% of hands to 33% while bidders make contract ~78%. A calibration test guards both figures. Leads keep the trump five back.
- **Animation:** played cards slide in from their seat's edge, the previous trick fades as the next lead arrives, the last trick's winning card is ringed in gold, and played cards lift out of the hand.
- **Living docs:** `docs/learning-path.md` indexes six explainer pages with Mermaid diagrams (build-and-run, architecture/MVVM, game-flow state machines, types-and-functions with proving tests, testing, decision log). CLAUDE.md requires updating them with code changes.

## Test plan
- [x] `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test` — 57 tests pass
- [x] Built with `scripts/build-simulator.py`, launched on the Catch 5 iPhone simulator; checked auction labels, contract line, readable hand, trump choice and play layout by screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)