### PR TITLE
One-command phone install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Initial dealing uses two packets of three starting left of dealer; refill goes c
 - `Sources/CatchFiveDemo`: the terminal demo.
 - `App/`: the nine-line app entry point, icon catalog and privacy manifest.
 - `Tests/`: 97 Swift Testing tests across engine and view model.
-- `scripts/`: `build-simulator.py` (hand-built simulator bundle), `make-icon.swift`, `export-docs.py` (PDF and PNG export for Claude Design).
+- `scripts/`: `install-phone.sh` (build, sign, install and launch on a connected iPhone), `build-simulator.py` (hand-built simulator bundle), `make-icon.swift`, `export-docs.py` (PDF and PNG export for Claude Design).
 - `docs/learning-path.md`: start here to read the code without an IDE; every page has diagrams.
 - `docs/catch-five-rules.md`: the house rules, which the in-app rules sheet quotes verbatim.
 - `docs/roadmap.md`: the six milestones, all done, and `docs/device-install.md`: putting the app on a phone.

--- a/Sources/CatchFiveUI/Tutorial/Lessons/TrumpLesson.swift
+++ b/Sources/CatchFiveUI/Tutorial/Lessons/TrumpLesson.swift
@@ -31,7 +31,7 @@ struct TrumpLesson: View {
             if correct {
                 Toggle("Discard and refill", isOn: $model.showRefill).tint(.gold).font(.footnote)
             }
-            Feedback(text: model.showRefill && correct ? "Three new cards, ringed in gold. One more spade came in; the two side cards stay because everything not spades was already thrown away." : model.trumpFeedback)
+            Feedback(text: model.showRefill && correct ? "Three new cards, ringed in gold: one more spade and two side cards drawn from the deck. Your three non-spades are gone." : model.trumpFeedback)
         }
     }
 }

--- a/docs/build-and-run.md
+++ b/docs/build-and-run.md
@@ -22,7 +22,7 @@ flowchart LR
 
 `Package.swift` declares five targets. Read it as a dependency list: `CatchFiveUI` depends on `CatchFive`, the app depends on `CatchFiveUI`, and nothing depends on the app. The arrows in the diagram only ever point right; the engine never knows a screen exists.
 
-## The five commands
+## The six commands
 
 | Command | What it does | When to use |
 |---|---|---|
@@ -30,6 +30,7 @@ flowchart LR
 | `... swift test --filter <name>` | Runs one test by function name | While working on one rule |
 | `... swift run catch-five-demo` | Plays a fixed five-hand match in the terminal and prints every trick | To watch the engine without the app. Add `--computer` for shuffled computer play, `--save-roundtrip` to see save/restore mid-trick |
 | `... python3 scripts/build-simulator.py` | Produces `work/simulator-build/CatchFive.app` for the iOS simulator | To run the real app |
+| `scripts/install-phone.sh` | Builds signed, installs and launches on the connected iPhone | Every time you want the latest build on the phone, and weekly to renew a free-team install ([device-install.md](device-install.md)) |
 | `python3 scripts/export-docs.py` | Renders every explainer page to PDF and every Mermaid diagram to PNG in `work/docs-export/` | To upload the pages to Claude Design or share them outside GitHub |
 
 `DEVELOPER_DIR` points the `swift` command at Xcode's toolchain rather than the command-line-tools copy, which lacks the iOS SDK.

--- a/docs/device-install.md
+++ b/docs/device-install.md
@@ -46,6 +46,14 @@ xcrun devicectl manage pair --device "Iphone"
 
 ## Each build
 
+The short way, from the repo root with the phone plugged in and unlocked:
+
+```bash
+scripts/install-phone.sh
+```
+
+It finds the connected phone, builds signed, installs and launches; about fifteen seconds on this Mac. Pass a device name or identifier to choose a phone. The long way, for reference:
+
 From Xcode: open `CatchFive.xcodeproj`, pick the phone as the run destination, press Run. The first run on a free team asks the phone to trust the developer: Settings, then General, then VPN & Device Management, tap your Apple ID, Trust.
 
 From the terminal, the same thing (this is the sequence that worked on 2026-09-05; the phone's device name is "Iphone", or use its identifier from `devicectl list devices`):

--- a/scripts/install-phone.sh
+++ b/scripts/install-phone.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Build Catch 5 signed for a connected, paired iPhone, install it and launch it.
+# Usage: scripts/install-phone.sh [device-name-or-id]
+# With a free personal team the install stops opening after seven days; run this again.
+set -e
+cd "$(dirname "$0")/.."
+export DEVELOPER_DIR="${DEVELOPER_DIR:-/Applications/Xcode.app/Contents/Developer}"
+
+device="${1:-}"
+if [ -z "$device" ]; then
+  # The first phone that is connected or available; the identifier is the UUID column.
+  device=$(xcrun devicectl list devices 2>/dev/null | grep -E ' (connected|available)' \
+    | grep -oE '[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}' | head -1)
+fi
+if [ -z "$device" ]; then
+  echo "No paired iPhone is connected. Plug it in, unlock it, then: xcrun devicectl manage pair --device <name>" >&2
+  exit 1
+fi
+
+echo "Building for $device"
+xcodebuild -project CatchFive.xcodeproj -scheme CatchFiveApp -destination "id=$device" \
+  -derivedDataPath work/derived -allowProvisioningUpdates build -quiet
+app=work/derived/Build/Products/Debug-iphoneos/CatchFiveApp.app
+echo "Installing $app"
+xcrun devicectl device install app --device "$device" "$app" >/dev/null
+echo "Launching"
+xcrun devicectl device process launch --device "$device" com.cardgame.catchfive >/dev/null
+echo "Catch 5 is running on the phone."


### PR DESCRIPTION
## Summary
`scripts/install-phone.sh` finds the connected iPhone, builds signed with automatic provisioning, installs and launches: about fifteen seconds end to end. It exists because a free personal team's install expires after seven days, so reinstalling should be one command. Documented in `docs/device-install.md`, the commands table in `docs/build-and-run.md`, and the README.

## Test plan
- [x] Ran from the main checkout with the phone connected: built, installed, launched

🤖 Generated with [Claude Code](https://claude.com/claude-code)