### PR TITLE
UI redesign spec: Passes 1–2 and the main menu (R1–R3, R13, R19–R26, R29–R32)

### DIFF
--- a/Sources/CatchFiveUI/GameModel.swift
+++ b/Sources/CatchFiveUI/GameModel.swift
@@ -117,8 +117,7 @@ public final class GameModel: ObservableObject {
         var parts = [seatNames[seat]]
         if seat != 0 { parts.append(Cast.seatWords[seat]) }
         if hand.phase == .bidding { parts.append(latestCall(for: seat) ?? "waiting") }
-        else if hand.auction.winner == seat { parts.append("bidder, \(hand.hands[seat].count) cards") }
-        else { parts.append("\(hand.hands[seat].count) cards") }
+        else if hand.auction.winner == seat { parts.append("bidder") }
         if hand.auction.dealer == seat { parts.append("dealer") }
         if hand.nextSeat == seat, match.winner == nil { parts.append("to act") }
         return parts.joined(separator: ", ")

--- a/Sources/CatchFiveUI/HandFanView.swift
+++ b/Sources/CatchFiveUI/HandFanView.swift
@@ -45,7 +45,7 @@ struct HandFanView: View {
             .onGeometryChange(for: Double.self) { $0.size.width } action: { measuredWidth = $0 }
             if !cards.isEmpty {
                 HStack(spacing: 8) {
-                    Text("YOUR HAND").opacity(0.55)
+                    Text("YOUR HAND").opacity(0.7)
                     if model.match.hand.auction.dealer == 0 {
                         Text("·").opacity(0.4)
                         Text("DEALER").foregroundStyle(.gold)

--- a/Sources/CatchFiveUI/HandFanView.swift
+++ b/Sources/CatchFiveUI/HandFanView.swift
@@ -102,7 +102,7 @@ struct HandFanView: View {
                 .combined(with: .scale(scale: 0.6)).combined(with: .opacity)
                 .animation(Theme.Motion.flight.delay(Theme.Motion.dealDelay + Double(index) * Theme.Motion.dealStagger))
             : .identity
-        // A discard flies to the pile under the deck in the top-right corner, shrinking to a card back.
+        // A discard flies to the pile in the top-left corner, shrinking to a card back.
         let removal: AnyTransition = hand.phase == .choosingTrump
             ? .offset(Self.discardTarget(index: index, count: model.humanCards.count, width: width))
                 .combined(with: .scale(scale: Theme.Table.deckWidth / scaledWidth)).combined(with: .opacity)
@@ -118,10 +118,10 @@ struct HandFanView: View {
         return CGSize(width: width - Theme.Table.deckWidth / 2 - cardCentre, height: -Theme.Table.deckRise)
     }
 
-    /// Where a discard lands: the pile just below the deck, in the same corner.
+    /// Where a discard lands: the pile in the top-left corner, level with the deck (spec R3).
     nonisolated static func discardTarget(index: Int, count: Int, width: Double) -> CGSize {
-        let origin = dealOrigin(index: index, count: count, width: width)
-        return CGSize(width: origin.width, height: origin.height + Theme.Table.discardDrop)
+        let cardCentre = (Double(index) + 0.5) * width / Double(max(count, 1))
+        return CGSize(width: Theme.Table.deckWidth * 0.85 / 2 - cardCentre, height: -Theme.Table.deckRise)
     }
 
     /// Cards rotate from −8° on the left to +8° on the right about their bottom edge.

--- a/Sources/CatchFiveUI/HandFanView.swift
+++ b/Sources/CatchFiveUI/HandFanView.swift
@@ -41,7 +41,7 @@ struct HandFanView: View {
                 }
             }
             .frame(maxWidth: .infinity, alignment: .bottom)
-            .frame(height: HandLayout.height(of: arrangement, cardWidth: scaledStandard))
+            .frame(height: HandLayout.height(of: arrangement, cardWidth: scaledWidth))
             .onGeometryChange(for: Double.self) { $0.size.width } action: { measuredWidth = $0 }
             if !cards.isEmpty {
                 HStack(spacing: 8) {

--- a/Sources/CatchFiveUI/MainMenuView.swift
+++ b/Sources/CatchFiveUI/MainMenuView.swift
@@ -3,8 +3,9 @@ import SwiftUI
 
 /// The main menu (spec R31): who is playing, where the saved match stands, and every destination that is
 /// not the table itself. Continue game leads back to the match untouched; New match replaces it after a
-/// word of warning; Settings, How to play, Statistics and the build explainer open as sheets, the last of
-/// them one tap from here in every mode (spec R29).
+/// word of warning; How to play opens the lessons. Settings, Statistics and the build explainer wait in a
+/// hamburger menu in the top-right corner, one tap from here in every mode (spec R29), as a bare glyph
+/// with no plate (spec R19).
 struct MainMenuView: View {
     @ObservedObject var model: GameModel
     @ObservedObject var tutorial: TutorialModel
@@ -51,13 +52,25 @@ struct MainMenuView: View {
                     } else {
                         MenuButtons.prominent("New match") { model.newGame(); onPlay() }
                     }
-                    MenuButtons.plain("Settings") { showSettings = true }
                     MenuButtons.plain("How to play") { showTutorial = true }
-                    MenuButtons.plain("Statistics") { showStatistics = true }
-                    MenuButtons.plain("How Catch 5 is built") { showExplainer = true }
                 }
             }
             .padding(24).frame(maxWidth: 480).frame(maxWidth: .infinity)
+        }
+        .overlay(alignment: .topTrailing) {
+            Menu {
+                Button("Settings", systemImage: "gearshape") { showSettings = true }
+                Button("Statistics", systemImage: "chart.bar") { showStatistics = true }
+                Button("How Catch 5 is built", systemImage: "doc.text.magnifyingglass") { showExplainer = true }
+            } label: {
+                Image(systemName: "line.3.horizontal").font(.title2.weight(.medium))
+                    .shadow(color: .black.opacity(0.45), radius: 1.5, y: 1)
+                    .frame(width: Theme.Table.statusButtonHitSize, height: Theme.Table.statusButtonHitSize)
+                    .contentShape(Rectangle())
+            }
+            .tint(.ivory)
+            .accessibilityLabel("Menu")
+            .padding(.trailing, 12).padding(.top, 4)
         }
         .foregroundStyle(.ivory)
         .background(LinearGradient(colors: [.felt, .black], startPoint: .topLeading, endPoint: .bottomTrailing).ignoresSafeArea())

--- a/Sources/CatchFiveUI/MainMenuView.swift
+++ b/Sources/CatchFiveUI/MainMenuView.swift
@@ -1,0 +1,73 @@
+import CatchFive
+import SwiftUI
+
+/// The main menu (spec R31): who is playing, where the saved match stands, and every destination that is
+/// not the table itself. Continue game leads back to the match untouched; New match replaces it after a
+/// word of warning; Settings, How to play, Statistics and the build explainer open as sheets, the last of
+/// them one tap from here in every mode (spec R29).
+struct MainMenuView: View {
+    @ObservedObject var model: GameModel
+    @ObservedObject var tutorial: TutorialModel
+    /// Continue or a fresh deal: the table takes over.
+    let onPlay: () -> Void
+    @State private var confirmNewMatch = false
+    @State private var showSettings = false
+    @State private var showTutorial = false
+    @State private var showStatistics = false
+    @State private var showExplainer = false
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 28) {
+                VStack(spacing: 4) {
+                    Text("CATCH 5").font(.system(.largeTitle, design: .serif).weight(.bold))
+                    Text("MAIN MENU").font(.system(.caption2, design: .monospaced).weight(.medium)).tracking(1).opacity(0.7)
+                }
+                .padding(.top, 40)
+
+                HStack(spacing: 14) {
+                    PortraitView(portrait: model.settings.playerPortrait, size: 56)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(model.settings.playerName ?? "friend")
+                            .font(.system(.title3, design: .serif).weight(.semibold)).lineLimit(1)
+                        Text(model.settings.difficulty == .easy ? "Easy opponents" : "Standard opponents")
+                            .font(.footnote).opacity(0.75)
+                        if let context = model.resumeContext {
+                            Text(context).font(.footnote).opacity(0.75)
+                        }
+                    }
+                    Spacer(minLength: 0)
+                }
+                .padding(16)
+                .background(.white.opacity(0.05), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                .accessibilityElement(children: .combine)
+
+                VStack(spacing: 10) {
+                    if model.match.winner == nil {
+                        MenuButtons.prominent("Continue game", action: onPlay)
+                        MenuButtons.plain("New match") {
+                            if model.matchInProgress { confirmNewMatch = true } else { model.newGame(); onPlay() }
+                        }
+                    } else {
+                        MenuButtons.prominent("New match") { model.newGame(); onPlay() }
+                    }
+                    MenuButtons.plain("Settings") { showSettings = true }
+                    MenuButtons.plain("How to play") { showTutorial = true }
+                    MenuButtons.plain("Statistics") { showStatistics = true }
+                    MenuButtons.plain("How Catch 5 is built") { showExplainer = true }
+                }
+            }
+            .padding(24).frame(maxWidth: 480).frame(maxWidth: .infinity)
+        }
+        .foregroundStyle(.ivory)
+        .background(LinearGradient(colors: [.felt, .black], startPoint: .topLeading, endPoint: .bottomTrailing).ignoresSafeArea())
+        .preferredColorScheme(.dark)
+        .sheet(isPresented: $showSettings) { SettingsView(settings: $model.settings) }
+        .sheet(isPresented: $showTutorial, onDismiss: { model.markRulesSeen() }) { TutorialView(model: tutorial) { showTutorial = false } }
+        .sheet(isPresented: $showStatistics) { StatisticsView(stats: model.statistics, records: model.records) { showStatistics = false } }
+        .fullScreenCoverOrSheet(isPresented: $showExplainer) { ExplainerView { showExplainer = false } }
+        .confirmationDialog("Start over? This replaces your saved game.", isPresented: $confirmNewMatch) {
+            Button("Start new match", role: .destructive) { model.newGame(); onPlay() }
+        }
+    }
+}

--- a/Sources/CatchFiveUI/RootView.swift
+++ b/Sources/CatchFiveUI/RootView.swift
@@ -1,9 +1,10 @@
 import SwiftUI
 
 /// Owns the one `GameModel`. A new player sees login, then the tutorial as an intro they may skip, then the
-/// table. A returning player lands on the table with a small welcome card over it.
+/// table. A returning player lands on the table with a small pause card over it; Main menu on that card, and
+/// Continue game on the menu, move between the menu and the table with the match preserved (spec R31, R32).
 public struct RootView: View {
-    enum Screen { case login, intro, table }
+    enum Screen { case login, intro, menu, table }
 
     @StateObject private var model: GameModel
     @StateObject private var tutorial: TutorialModel
@@ -45,6 +46,8 @@ public struct RootView: View {
                 LoginView(model: model) { startFirstMatch() }.transition(.opacity)
             case .intro:
                 IntroView(model: model, tutorial: tutorial) { model.markRulesSeen(); show(.table) }.transition(.opacity)
+            case .menu:
+                MainMenuView(model: model, tutorial: tutorial) { showWelcome = false; show(.table) }.transition(.opacity)
             case .table:
                 TableView(model: model, tutorial: tutorial, covered: showWelcome) { withAnimation(motion) { showWelcome = true } }
                     .transition(.opacity)
@@ -54,7 +57,8 @@ public struct RootView: View {
                         if showWelcome {
                             ZStack {
                                 Color.black.opacity(contrast == .increased ? 0.75 : 0.55).ignoresSafeArea()
-                                WelcomeCard(model: model) { withAnimation(motion) { showWelcome = false } }
+                                WelcomeCard(model: model, onPlay: { withAnimation(motion) { showWelcome = false } },
+                                            onMenu: { showWelcome = false; show(.menu) })
                             }
                             .transition(.opacity)
                             .accessibilityAddTraits(.isModal)

--- a/Sources/CatchFiveUI/ScoreBarView.swift
+++ b/Sources/CatchFiveUI/ScoreBarView.swift
@@ -21,11 +21,24 @@ struct ScoreBarView: View {
     var body: some View {
         VStack(spacing: 6) {
             HStack(alignment: .firstTextBaseline) {
+                // A labelled pill, not a bare chevron: the way back to the welcome card should read as a button.
                 Button(action: onLeave) {
-                    Image(systemName: "chevron.left").font(.title3).frame(width: 44, height: 44, alignment: .leading)
+                    HStack(spacing: 4) {
+                        Image(systemName: "chevron.left")
+                        Text("Home")
+                    }
+                    .font(.subheadline.weight(.semibold))
+                    .padding(.horizontal, 10).padding(.vertical, 6)
+                    .background(Theme.Wood.inlay.opacity(0.7), in: Capsule())
+                    .overlay(Capsule().stroke(.ivory.opacity(0.18), lineWidth: 1))
+                    .frame(minHeight: 44)
+                    .contentShape(Rectangle())
                 }
-                .tint(.ivory.opacity(0.7))
-                .accessibilityLabel("Back to menu")
+                .buttonStyle(.plain)
+                .foregroundStyle(.ivory)
+                .accessibilityLabel("Home")
+                .accessibilityHint("Shows the welcome card: continue this game, start a new match, or open Settings")
+                .padding(.trailing, 6)
                 Text("CATCH 5").font(.system(.title3, design: .serif).weight(.bold)).lineLimit(1).minimumScaleFactor(0.7)
                 Text("HAND \(handNumber)").font(.system(.subheadline, design: .monospaced)).opacity(0.7)
                     .padding(.leading, 12)

--- a/Sources/CatchFiveUI/ScoreBarView.swift
+++ b/Sources/CatchFiveUI/ScoreBarView.swift
@@ -21,16 +21,14 @@ struct ScoreBarView: View {
     var body: some View {
         VStack(spacing: 6) {
             HStack(alignment: .firstTextBaseline) {
-                // A labelled pill, not a bare chevron: the way back to the welcome card should read as a button.
+                // Chevron and word, no plate (spec R16): the way back to the welcome card reads as a button
+                // because it says where it goes, not because it is boxed.
                 Button(action: onLeave) {
                     HStack(spacing: 4) {
-                        Image(systemName: "chevron.left")
-                        Text("Home")
+                        Image(systemName: "chevron.left").font(.subheadline.weight(.bold))
+                        Text("Home").font(.subheadline.weight(.semibold))
                     }
-                    .font(.subheadline.weight(.semibold))
-                    .padding(.horizontal, 10).padding(.vertical, 6)
-                    .background(Theme.Wood.inlay.opacity(0.7), in: Capsule())
-                    .overlay(Capsule().stroke(.ivory.opacity(0.18), lineWidth: 1))
+                    .shadow(color: .black.opacity(0.35), radius: 1, y: 1)
                     .frame(minHeight: 44)
                     .contentShape(Rectangle())
                 }

--- a/Sources/CatchFiveUI/ScoreBarView.swift
+++ b/Sources/CatchFiveUI/ScoreBarView.swift
@@ -1,14 +1,24 @@
 import CatchFive
 import SwiftUI
 
-/// The compact bar pinned above the table: title with the hand number, the menu, and both scores.
-/// Trump, contract and the dealer live on the table itself (`TableSurface.contractPill`, `HandFanView`).
+/// The bar pinned above the table, one row (spec R1): the way home, a score chip that opens the score
+/// sheet, the contract chip once bidding has resolved, and the menu. Nothing else lives up here; the
+/// hand number is on the score sheet, the seat to act is ringed at the table, and the dealer badge sits
+/// on the hand's label.
 struct ScoreBarView: View {
+    /// What the contract chip shows: the bid and who holds it, plus trump once it is named.
+    struct Contract: Equatable {
+        let trump: Suit?
+        let bid: Int
+        let isNineAndOut: Bool
+        let bidder: String
+    }
+
     let us: Int
     let them: Int
     let usLabel: String
     let themLabel: String
-    let handNumber: Int
+    let contract: Contract?
     let canUndo: Bool
     let onUndo: () -> Void
     let onScores: () -> Void
@@ -19,62 +29,75 @@ struct ScoreBarView: View {
     let onLeave: () -> Void
 
     var body: some View {
-        VStack(spacing: 6) {
-            HStack(alignment: .firstTextBaseline) {
-                // Chevron and word, no plate (spec R16): the way back to the welcome card reads as a button
-                // because it says where it goes, not because it is boxed.
-                Button(action: onLeave) {
-                    HStack(spacing: 4) {
-                        Image(systemName: "chevron.left").font(.subheadline.weight(.bold))
-                        Text("Home").font(.subheadline.weight(.semibold))
-                    }
-                    .shadow(color: .black.opacity(0.35), radius: 1, y: 1)
-                    .frame(minHeight: 44)
-                    .contentShape(Rectangle())
+        HStack(spacing: 10) {
+            // Chevron and word, no plate (spec R16): the way back to the welcome card reads as a button
+            // because it says where it goes, not because it is boxed.
+            Button(action: onLeave) {
+                HStack(spacing: 4) {
+                    Image(systemName: "chevron.left").font(.subheadline.weight(.bold))
+                    Text("Home").font(.subheadline.weight(.semibold))
                 }
-                .buttonStyle(.plain)
-                .foregroundStyle(.ivory)
-                .accessibilityLabel("Home")
-                .accessibilityHint("Shows the welcome card: continue this game, start a new match, or open Settings")
-                .padding(.trailing, 6)
-                Text("CATCH 5").font(.system(.title3, design: .serif).weight(.bold)).lineLimit(1).minimumScaleFactor(0.7)
-                Text("HAND \(handNumber)").font(.system(.subheadline, design: .monospaced)).opacity(0.7)
-                    .padding(.leading, 12)
-                    .accessibilityLabel("Hand \(handNumber)")
-                Spacer()
-                Menu {
-                    Button("Undo last action", systemImage: "arrow.uturn.backward", action: onUndo).disabled(!canUndo)
-                    Divider()
-                    Button("Settings", systemImage: "gearshape", action: onSettings)
-                    Button("Statistics", systemImage: "chart.bar", action: onStatistics)
-                    Button("How to play", systemImage: "book", action: onTutorial)
-                    Divider()
-                    Button("Start a new game", systemImage: "arrow.counterclockwise", role: .destructive, action: onNewGame)
-                } label: {
-                    Image(systemName: "gearshape").font(.title3).frame(width: 44, height: 44, alignment: .trailing)
-                }
-                .tint(.ivory.opacity(0.7))
-                .accessibilityLabel("Menu")
-            }
-            Button(action: onScores) {
-                VStack(spacing: 2) {
-                    HStack(alignment: .firstTextBaseline) {
-                        team(usLabel, us, .leading)
-                        Spacer(minLength: 12)
-                        team(themLabel, them, .trailing)
-                    }
-                }
+                .shadow(color: .black.opacity(0.35), radius: 1, y: 1)
+                .frame(minHeight: 44)
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("Home")
+            .accessibilityHint("Shows the welcome card: continue this game, start a new match, or open Settings")
+
+            Button(action: onScores) {
+                HStack(spacing: 4) {
+                    Text("Us").opacity(0.7)
+                    Text(us, format: .number).font(.system(.title3, design: .serif).weight(.semibold))
+                    Text("·").opacity(0.5)
+                    Text("Them").opacity(0.7)
+                    Text(them, format: .number).font(.system(.title3, design: .serif).weight(.semibold))
+                }
+                .font(.subheadline.weight(.semibold)).monospacedDigit()
+                .lineLimit(1).minimumScaleFactor(0.7)
+                .frame(minHeight: 44)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("\(usLabel) \(us), \(themLabel) \(them)")
             .accessibilityHint("Shows every hand of this match")
+
+            Spacer(minLength: 4)
+            if let contract { contractChip(contract) }
+            Spacer(minLength: 4)
+
+            Menu {
+                Button("Undo last action", systemImage: "arrow.uturn.backward", action: onUndo).disabled(!canUndo)
+                Divider()
+                Button("Settings", systemImage: "gearshape", action: onSettings)
+                Button("Statistics", systemImage: "chart.bar", action: onStatistics)
+                Button("How to play", systemImage: "book", action: onTutorial)
+                Divider()
+                Button("Start a new game", systemImage: "arrow.counterclockwise", role: .destructive, action: onNewGame)
+            } label: {
+                Image(systemName: "gearshape").font(.title3).frame(width: 44, height: 44, alignment: .trailing)
+                    .shadow(color: .black.opacity(0.35), radius: 1, y: 1)
+            }
+            .tint(.ivory)
+            .accessibilityLabel("Menu")
         }
+        .foregroundStyle(.ivory)
     }
 
-    private func team(_ label: String, _ value: Int, _ alignment: HorizontalAlignment) -> some View {
-        VStack(alignment: alignment, spacing: 0) {
-            Text(label).font(.system(.caption2, design: .monospaced)).opacity(0.7).lineLimit(1).minimumScaleFactor(0.7)
-            Text(value, format: .number).font(.system(.title, design: .serif).weight(.semibold)).monospacedDigit()
-        }.accessibilityElement(children: .combine)
+    /// "♣ 3 — Otto" in gold (rule 2), the suit in its own colour; "9 and out" spelled out.
+    private func contractChip(_ contract: Contract) -> some View {
+        HStack(spacing: 5) {
+            if let trump = contract.trump {
+                Text(trump.glyph).foregroundStyle(trump.isRed ? Color.suitRed : .ivory)
+            }
+            Text(contract.isNineAndOut ? "9 and out" : String(contract.bid))
+            Text("—").opacity(0.6)
+            Text(contract.bidder)
+        }
+        .font(.system(.subheadline, design: .serif).weight(.semibold))
+        .foregroundStyle(.gold)
+        .lineLimit(1).minimumScaleFactor(0.7)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Contract: \(contract.bidder) bid \(contract.isNineAndOut ? "9 and out" : String(contract.bid))\(contract.trump.map { ", \($0.rawValue) trump" } ?? "")")
     }
 }

--- a/Sources/CatchFiveUI/TableSurface.swift
+++ b/Sources/CatchFiveUI/TableSurface.swift
@@ -181,22 +181,38 @@ struct TableSurface: View {
 
     private var statusLine: some View {
         HStack(spacing: 8) {
-            // Left: reopen the last trick when the pile is clear. Right: the hint on your turn.
-            if pile.plays.isEmpty, hand.completedTricks.last != nil, hand.phase == .playing, reopenedTrick == nil {
-                smallButton("rectangle.stack", label: "Show the last trick", action: onReopenTrick)
-            } else if reopenedTrick != nil {
-                // Play waits while the trick is open, so there must be a way to put it down again.
-                smallButton("xmark", label: "Hide the last trick", action: onCloseTrick)
-            } else {
+            if reopenedTrick != nil {
+                // Reviewing the last trick is its own state (spec R24): say so, and name the way back.
+                // Play waits while the trick is open; no hint is offered, since nothing is being decided.
+                Button(action: onCloseTrick) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "chevron.left").font(.subheadline.weight(.bold))
+                        Text("Back to play").font(.subheadline.weight(.semibold))
+                    }
+                    .frame(minHeight: Theme.Table.statusButtonHitSize)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Back to play")
+                Text("Reviewing last trick").font(.title3.weight(.medium)).lineLimit(1).minimumScaleFactor(0.7)
+                    .frame(maxWidth: .infinity)
+                    .accessibilityFocused(statusFocus)
                 Spacer().frame(width: Theme.Table.statusButtonHitSize, height: Theme.Table.statusButtonHitSize)
-            }
-            statusText.font(.title3.weight(.medium)).multilineTextAlignment(.center).frame(maxWidth: .infinity)
-                .lineLimit(1).minimumScaleFactor(0.7)
-                .accessibilityFocused(statusFocus)
-            if model.isHumanTurn, hand.phase != .finished {
-                smallButton("lightbulb", label: "Hint") { model.showHint() }
             } else {
-                Spacer().frame(width: Theme.Table.statusButtonHitSize, height: Theme.Table.statusButtonHitSize)
+                // Left: reopen the last trick when the pile is clear. Right: the hint on your turn.
+                if pile.plays.isEmpty, hand.completedTricks.last != nil, hand.phase == .playing {
+                    smallButton("rectangle.stack", label: "Show the last trick", action: onReopenTrick)
+                } else {
+                    Spacer().frame(width: Theme.Table.statusButtonHitSize, height: Theme.Table.statusButtonHitSize)
+                }
+                statusText.font(.title3.weight(.medium)).multilineTextAlignment(.center).frame(maxWidth: .infinity)
+                    .lineLimit(1).minimumScaleFactor(0.7)
+                    .accessibilityFocused(statusFocus)
+                if model.isHumanTurn, hand.phase != .finished {
+                    smallButton("lightbulb", label: "Hint") { model.showHint() }
+                } else {
+                    Spacer().frame(width: Theme.Table.statusButtonHitSize, height: Theme.Table.statusButtonHitSize)
+                }
             }
         }
     }
@@ -267,7 +283,7 @@ struct TableSurface: View {
             } else if hand.phase == .bidding, !model.isHumanTurn, let call = model.latestCall(for: 0) {
                 Text("You: \(call)").font(.footnote).opacity(0.85)
             } else if !inAuction {
-                Text(pile.plays.isEmpty ? " " : "Tap a card to see why it was played")
+                Text(pile.plays.isEmpty ? " " : (reopenedTrick != nil ? "Tap a card to see why it was played" : "Tap a card on the table to see why it was played"))
                     .font(.footnote).foregroundStyle(.ivory.opacity(0.5))
                     .accessibilityHidden(true)
             }

--- a/Sources/CatchFiveUI/TableSurface.swift
+++ b/Sources/CatchFiveUI/TableSurface.swift
@@ -20,6 +20,8 @@ struct TableSurface: View {
     /// VoiceOver focus lands on the status line when a cover lifts or the turn changes.
     let statusFocus: AccessibilityFocusState<Bool>.Binding
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    /// The hint's full reason, opened from its Why? control (spec R22).
+    @State private var showHintDetail = false
 
     private var hand: Hand { model.match.hand }
 
@@ -272,12 +274,27 @@ struct TableSurface: View {
                 .padding(.horizontal, 14).padding(.vertical, 6)
                 .background(Theme.Wood.inlay.opacity(0.85), in: Capsule())
                 .transition(reduceMotion ? .opacity : .move(edge: .bottom).combined(with: .opacity))
-            } else if let text = model.hint?.reason ?? model.explanation {
+            } else if let hint = model.hint {
+                // One complete recommendation on one line; the reason waits behind Why?, so a long hint
+                // can never push the controls above it off the screen (spec R22).
+                let parts = Self.hintParts(hint.reason)
+                HStack(spacing: 10) {
+                    Text(parts.recommendation).font(.footnote.weight(.semibold)).lineLimit(1).minimumScaleFactor(0.8)
+                    if !parts.detail.isEmpty {
+                        Button("Why?") { showHintDetail = true }
+                            .font(.footnote.weight(.semibold)).tint(.ivory).underline()
+                            .accessibilityHint("Opens the reason for this hint")
+                    }
+                }
+                .foregroundStyle(.ivory)
+                .padding(.horizontal, 8)
+                .accessibilityElement(children: .contain)
+                .accessibilityLabel("Hint: \(parts.recommendation)")
+            } else if let text = model.explanation {
                 Text(text)
                     .font(.footnote).multilineTextAlignment(.center)
                     .foregroundStyle(.ivory.opacity(0.85))
                     .padding(.horizontal, 8)
-                    .accessibilityLabel(model.hint != nil ? "Hint: \(text)" : text)
             } else if let notice = model.notice {
                 Text(notice).font(.footnote).opacity(0.85)
             } else if hand.phase == .bidding, !model.isHumanTurn, let call = model.latestCall(for: 0) {
@@ -290,6 +307,21 @@ struct TableSurface: View {
         }
         .frame(maxWidth: .infinity, minHeight: inAuction && model.isHumanTurn ? 0 : 36, alignment: .top)
         .animation(reduceMotion ? Theme.Motion.reduced : Theme.Motion.overlay, value: toast)
+        .sheet(isPresented: $showHintDetail) {
+            if let hint = model.hint {
+                HintDetailView(parts: Self.hintParts(hint.reason))
+            }
+        }
+    }
+
+    /// Advice reads "Play the six of clubs: partner's queen holds the trick, so…". The part before the
+    /// colon is the recommendation; the rest, with a capital, is the reason. No colon: all recommendation.
+    nonisolated static func hintParts(_ reason: String) -> (recommendation: String, detail: String) {
+        guard let colon = reason.firstIndex(of: ":") else { return (reason, "") }
+        let recommendation = String(reason[..<colon]).trimmingCharacters(in: .whitespaces)
+        let rest = reason[reason.index(after: colon)...].trimmingCharacters(in: .whitespaces)
+        guard let first = rest.first else { return (recommendation, "") }
+        return (recommendation, first.uppercased() + rest.dropFirst())
     }
 
     // MARK: Phase controls
@@ -526,3 +558,25 @@ struct DiscardPileView: View {
 private func + (lhs: CGSize, rhs: CGSize) -> CGSize {
     CGSize(width: lhs.width + rhs.width, height: lhs.height + rhs.height)
 }
+
+/// The hint's reason, in a short sheet over the table: bounded, scrollable, never in the way of a control.
+struct HintDetailView: View {
+    let parts: (recommendation: String, detail: String)
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("HINT").font(.system(.caption, design: .monospaced)).tracking(1).opacity(0.7)
+                Text(parts.recommendation).font(.system(.title3, design: .serif).weight(.bold))
+                Text(parts.detail).font(.body).lineSpacing(2).fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(24)
+        }
+        .foregroundStyle(.ivory)
+        .background(WoodGrainView().ignoresSafeArea())
+        .presentationDetents([.fraction(0.35), .medium])
+        .presentationDragIndicator(.visible)
+    }
+}
+

--- a/Sources/CatchFiveUI/TableSurface.swift
+++ b/Sources/CatchFiveUI/TableSurface.swift
@@ -44,7 +44,6 @@ struct TableSurface: View {
                 // Three groups spread over the full height: the contract under the header, the seats and
                 // pile in the middle, and the status line with its controls down by the hand.
                 VStack(spacing: 6) {
-                    HStack { contractPill.accessibilitySortPriority(25); Spacer(minLength: 0) }
                     Spacer(minLength: 4)
                     SeatView(model: model, seat: 2).accessibilitySortPriority(20)
                     // The side tiles give way before the pile can touch them (`TableLayout`); in the auction
@@ -155,28 +154,6 @@ struct TableSurface: View {
         let removal: AnyTransition = .offset(x: to.width * reach.width, y: to.height * reach.height)
             .combined(with: .scale(scale: 0.5)).combined(with: .opacity)
         return .asymmetric(insertion: insertion, removal: removal)
-    }
-
-    // MARK: Contract
-
-    /// Trump and the contract, in gold (rule 2), as plain text at the table's top-left once trump is
-    /// named: no pill, so it sits in the felt like a scorer's note.
-    @ViewBuilder private var contractPill: some View {
-        if let trump = hand.trump {
-            HStack(spacing: 8) {
-                Text(trump.glyph).font(.title2).foregroundStyle(trump.isRed ? Color.suitRed : .ivory)
-                Text("Trump")
-                if let contract = model.contract {
-                    Text("·").opacity(0.5)
-                    Text(contract)
-                }
-            }
-            .font(.system(.body, design: .serif).weight(.semibold))
-            .foregroundStyle(.gold)
-            .lineLimit(1).minimumScaleFactor(0.8)
-            .padding(.leading, 4).padding(.top, 10)
-            .accessibilityElement(children: .combine)
-        }
     }
 
     // MARK: Status, hints, explanations

--- a/Sources/CatchFiveUI/TableSurface.swift
+++ b/Sources/CatchFiveUI/TableSurface.swift
@@ -45,8 +45,9 @@ struct TableSurface: View {
                     HStack { contractPill.accessibilitySortPriority(25); Spacer(minLength: 0) }
                     Spacer(minLength: 4)
                     SeatView(model: model, seat: 2).accessibilitySortPriority(20)
-                    // The side tiles give way before the pile can touch them (`TableLayout`).
-                    let sideWidth = TableLayout.sideSeatWidth(available: geometry.size.width)
+                    // The side tiles give way before the pile can touch them (`TableLayout`); in the auction
+                    // there is no pile, so they keep their full width.
+                    let sideWidth = inAuction ? Theme.Table.seatTileWidth : TableLayout.sideSeatWidth(available: geometry.size.width)
                     HStack(alignment: .center) {
                         SeatView(model: model, seat: 1, width: sideWidth).accessibilitySortPriority(30)
                         Spacer(minLength: TableLayout.seatGap)
@@ -385,36 +386,41 @@ struct SeatView: View {
     private var hand: Hand { model.match.hand }
     private var active: Bool { hand.nextSeat == seat && model.match.winner == nil }
 
-    /// One fixed size in every phase: name on top, the call or the card-back stack in the middle, and a
-    /// badge line that is always reserved, so tiles never grow or shrink as the hand moves on.
+    /// Portrait beside the name, with the call or the card-back stack under the name and a badge line only
+    /// when a badge applies. Laid out sideways so a row of seats costs the height of one portrait, not a
+    /// stack of four lines; that is what leaves the auction its bottom row of controls (spec R21).
     var body: some View {
-        VStack(spacing: 4) {
+        HStack(alignment: .center, spacing: 8) {
             PortraitView(portrait: portrait, size: Theme.Table.portraitSize, expression: SeatMood.expression(for: seat, in: model.match))
-            Text(model.seatNames[seat]).font(.headline).lineLimit(1).minimumScaleFactor(0.7)
-            ZStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(model.seatNames[seat]).font(.headline).lineLimit(1).minimumScaleFactor(0.7)
                 if hand.phase == .bidding {
-                    Text(model.latestCall(for: seat) ?? "Waiting").font(.caption).opacity(0.75).lineLimit(1)
+                    Text(model.latestCall(for: seat) ?? "Waiting").font(.caption).opacity(0.75).lineLimit(1).minimumScaleFactor(0.8)
                 } else {
-                    ForEach(0..<min(3, max(1, hand.hands[seat].count)), id: \.self) { index in
-                        CardBackView(width: Theme.Table.seatBackWidth)
-                            .offset(x: Double(index) * 4 - 4)
+                    ZStack(alignment: .leading) {
+                        ForEach(0..<min(3, max(1, hand.hands[seat].count)), id: \.self) { index in
+                            CardBackView(width: Theme.Table.seatBackWidth)
+                                .offset(x: Double(index) * 4)
+                        }
+                        Text(hand.hands[seat].count, format: .number).font(.caption.weight(.bold).monospacedDigit())
+                            .padding(.horizontal, 5).padding(.vertical, 1)
+                            .background(.black.opacity(0.55), in: Capsule())
+                            .offset(x: Theme.Table.seatBackWidth * 0.9, y: Theme.Table.seatBackWidth * 0.55)
                     }
-                    Text(hand.hands[seat].count, format: .number).font(.caption.weight(.bold).monospacedDigit())
-                        .padding(.horizontal, 5).padding(.vertical, 1)
-                        .background(.black.opacity(0.55), in: Capsule())
-                        .offset(x: Theme.Table.seatBackWidth * 0.65, y: Theme.Table.seatBackWidth * 0.55)
+                    .frame(height: Theme.Table.seatBackWidth * Theme.Card.ratio + 4)
+                    .dynamicTypeSize(...Theme.Card.maximumTypeSize)
+                }
+                if hand.auction.dealer == seat || (hand.auction.winner == seat && hand.phase != .bidding) {
+                    HStack(spacing: 6) {
+                        if hand.auction.dealer == seat { Text("DEALER").foregroundStyle(.gold) }
+                        if hand.auction.winner == seat, hand.phase != .bidding { Text("BIDDER").opacity(0.7) }
+                    }
+                    .font(.system(.caption2, design: .monospaced)).lineLimit(1).minimumScaleFactor(0.7)
                 }
             }
-            .frame(height: Theme.Table.seatBackWidth * Theme.Card.ratio + 4)
-            .dynamicTypeSize(...Theme.Card.maximumTypeSize)
-            HStack(spacing: 6) {
-                if hand.auction.dealer == seat { Text("DEALER").foregroundStyle(.gold) }
-                if hand.auction.winner == seat, hand.phase != .bidding { Text("BIDDER").opacity(0.7) }
-            }
-            .font(.system(.caption2, design: .monospaced)).lineLimit(1).minimumScaleFactor(0.7)
-            .frame(height: 15)
+            Spacer(minLength: 0)
         }
-        .padding(.horizontal, 10).padding(.vertical, 6)
+        .padding(.horizontal, 6).padding(.vertical, 6)
         .frame(width: width)
         // No fill: the name, backs and badges sit straight on the felt; only the seat to act gets a ring.
         .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous).stroke(.gold, lineWidth: active ? 2 : 0))

--- a/Sources/CatchFiveUI/TableSurface.swift
+++ b/Sources/CatchFiveUI/TableSurface.swift
@@ -446,15 +446,12 @@ struct SeatView: View {
                 if hand.phase == .bidding {
                     Text(model.latestCall(for: seat) ?? "Waiting").font(.caption).opacity(0.75).lineLimit(1).minimumScaleFactor(0.8)
                 } else {
+                    // The stack's thickness says roughly how many cards are left; there is no number (spec R20).
                     ZStack(alignment: .leading) {
                         ForEach(0..<min(3, max(1, hand.hands[seat].count)), id: \.self) { index in
                             CardBackView(width: Theme.Table.seatBackWidth)
                                 .offset(x: Double(index) * 4)
                         }
-                        Text(hand.hands[seat].count, format: .number).font(.caption.weight(.bold).monospacedDigit())
-                            .padding(.horizontal, 5).padding(.vertical, 1)
-                            .background(.black.opacity(0.55), in: Capsule())
-                            .offset(x: Theme.Table.seatBackWidth * 0.9, y: Theme.Table.seatBackWidth * 0.55)
                     }
                     .frame(height: Theme.Table.seatBackWidth * Theme.Card.ratio + 4)
                     .dynamicTypeSize(...Theme.Card.maximumTypeSize)
@@ -510,48 +507,44 @@ struct PillButtonStyle: ButtonStyle {
     }
 }
 
-/// The undealt stock: a small stack of card backs with the count, in the table's top-right corner.
+/// The undealt stock in the table's top-right corner. Its thickness says roughly how much is left;
+/// there is no number, because counting is the player's skill, not the app's (spec R20).
 struct DeckView: View {
     let remaining: Int
 
+    /// One back per six cards or part of one, so a full stock reads as five and a near-empty one as one.
+    nonisolated static func thickness(_ count: Int) -> Int { max(1, min(5, (count + 5) / 6)) }
+
     var body: some View {
         ZStack(alignment: .bottomTrailing) {
-            ForEach(0..<3, id: \.self) { index in
+            ForEach(0..<Self.thickness(remaining), id: \.self) { index in
                 CardBackView(width: Theme.Table.deckWidth)
                     .offset(x: Double(index) * -2, y: Double(index) * -2)
             }
-            Text(remaining, format: .number).font(.caption2.weight(.bold).monospacedDigit())
-                .padding(.horizontal, 5).padding(.vertical, 1)
-                .background(.black.opacity(0.6), in: Capsule())
-                .offset(x: 6, y: 6)
         }
         .dynamicTypeSize(...Theme.Card.maximumTypeSize)
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel("\(remaining) cards in the deck")
+        .accessibilityLabel("Deck")
     }
 }
 
-/// The discards, face down under the deck, with their count: nothing about them is a secret worth
-/// keeping (the rules put them out of play), but nothing about them needs showing either.
+/// The discards, face down under the deck: nothing about them is a secret worth keeping (the rules put
+/// them out of play), but nothing about them needs showing either, so no number here (spec R20).
 struct DiscardPileView: View {
     let count: Int
 
     var body: some View {
         ZStack(alignment: .bottomTrailing) {
-            ForEach(0..<min(3, count), id: \.self) { index in
+            ForEach(0..<min(3, DeckView.thickness(count)), id: \.self) { index in
                 CardBackView(width: Theme.Table.deckWidth * 0.85)
                     .rotationEffect(.degrees(Double(index) * 5 - 5))
                     .offset(x: Double(index) * -1.5, y: Double(index) * -1.5)
             }
-            Text(count, format: .number).font(.caption2.weight(.bold).monospacedDigit())
-                .padding(.horizontal, 5).padding(.vertical, 1)
-                .background(.black.opacity(0.6), in: Capsule())
-                .offset(x: 6, y: 6)
         }
         .opacity(0.8)
         .dynamicTypeSize(...Theme.Card.maximumTypeSize)
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel("\(count) cards discarded")
+        .accessibilityLabel("Discard pile")
     }
 }
 

--- a/Sources/CatchFiveUI/TableSurface.swift
+++ b/Sources/CatchFiveUI/TableSurface.swift
@@ -67,16 +67,13 @@ struct TableSurface: View {
             }
             .scrollBounceBehavior(.basedOnSize)
             .frame(width: geometry.size.width, height: geometry.size.height)
-            // The stock sits in the top-right corner of the table; refills deal in from here.
-            .overlay(alignment: .topTrailing) {
-                // The stock, and beneath it the discards: the cards that left every hand when trump was named.
-                VStack(spacing: 10) {
-                    DeckView(remaining: hand.stock.count)
-                    if !hand.discarded.isEmpty {
-                        DiscardPileView(count: hand.discarded.count).transition(.opacity)
-                    }
+            // The stock sits in the top-right corner of the table; refills deal in from here. The discards
+            // mirror it in the top-left, clear of the hand (spec R3), and discards fly there.
+            .overlay(alignment: .topTrailing) { DeckView(remaining: hand.stock.count).padding(.top, 6) }
+            .overlay(alignment: .topLeading) {
+                if !hand.discarded.isEmpty {
+                    DiscardPileView(count: hand.discarded.count).padding(.top, 6).transition(.opacity)
                 }
-                .padding(.top, 6)
             }
             // The finished hand's card takes over the table; what is underneath fades back and leaves the
             // accessibility tree, so VoiceOver meets the card and nothing behind it.
@@ -508,17 +505,17 @@ struct DeckView: View {
     }
 }
 
-/// The discards, face down under the deck: nothing about them is a secret worth keeping (the rules put
+/// The discards, face down in the top-left corner: nothing about them is a secret worth keeping (the rules put
 /// them out of play), but nothing about them needs showing either, so no number here (spec R20).
 struct DiscardPileView: View {
     let count: Int
 
     var body: some View {
-        ZStack(alignment: .bottomTrailing) {
+        ZStack(alignment: .bottomLeading) {
             ForEach(0..<min(3, DeckView.thickness(count)), id: \.self) { index in
                 CardBackView(width: Theme.Table.deckWidth * 0.85)
-                    .rotationEffect(.degrees(Double(index) * 5 - 5))
-                    .offset(x: Double(index) * -1.5, y: Double(index) * -1.5)
+                    .rotationEffect(.degrees(5 - Double(index) * 5))
+                    .offset(x: Double(index) * 1.5, y: Double(index) * -1.5)
             }
         }
         .opacity(0.8)

--- a/Sources/CatchFiveUI/TableSurface.swift
+++ b/Sources/CatchFiveUI/TableSurface.swift
@@ -410,47 +410,71 @@ struct SeatView: View {
     let seat: Int
     /// Side tiles take the width the row can spare; the partner's tile keeps the full width.
     var width: Double = Theme.Table.seatTileWidth
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    /// The halo's breathing, driven by a repeating animation while this seat is deciding.
+    @State private var pulsing = false
+    @ScaledMetric(relativeTo: .title2) private var backWidth = Theme.Table.seatBackWidth
 
     private var hand: Hand { model.match.hand }
     private var active: Bool { hand.nextSeat == seat && model.match.winner == nil }
 
-    /// Portrait beside the name, with the call or the card-back stack under the name and a badge line only
-    /// when a badge applies. Laid out sideways so a row of seats costs the height of one portrait, not a
-    /// stack of four lines; that is what leaves the auction its bottom row of controls (spec R21).
+    /// A face over a name over one line of badges: the call in the auction, a hint of a hand in play, and
+    /// DEALER or BIDDER when they apply. Everything a seat says sits under its own portrait, so nothing
+    /// about a player floats elsewhere on the table (spec R2). The seat to act wears a gold halo that
+    /// breathes; that halo is the table's only turn indicator.
     var body: some View {
-        HStack(alignment: .center, spacing: 6) {
+        VStack(spacing: 2) {
             PortraitView(portrait: portrait, size: Theme.Table.portraitSize, expression: SeatMood.expression(for: seat, in: model.match))
-            VStack(alignment: .leading, spacing: 2) {
-                Text(model.seatNames[seat]).font(.headline).lineLimit(1).minimumScaleFactor(0.6)
-                if hand.phase == .bidding {
-                    Text(model.latestCall(for: seat) ?? "Waiting").font(.caption).opacity(0.75).lineLimit(1).minimumScaleFactor(0.8)
-                } else {
-                    // The stack's thickness says roughly how many cards are left; there is no number (spec R20).
-                    ZStack(alignment: .leading) {
-                        ForEach(0..<min(3, max(1, hand.hands[seat].count)), id: \.self) { index in
-                            CardBackView(width: Theme.Table.seatBackWidth)
-                                .offset(x: Double(index) * 4)
-                        }
-                    }
-                    .frame(height: Theme.Table.seatBackWidth * Theme.Card.ratio + 4)
-                    .dynamicTypeSize(...Theme.Card.maximumTypeSize)
+                .overlay {
+                    Circle().stroke(.gold, lineWidth: Theme.Table.activeRingWidth)
+                        .padding(-Theme.Table.activeRingGap)
+                        .opacity(active ? 1 : 0)
                 }
-                if hand.auction.dealer == seat || (hand.auction.winner == seat && hand.phase != .bidding) {
-                    HStack(spacing: 6) {
-                        if hand.auction.dealer == seat { Text("DEALER").foregroundStyle(.gold) }
-                        if hand.auction.winner == seat, hand.phase != .bidding { Text("BIDDER").opacity(0.7) }
+                .scaleEffect(pulsing ? Theme.Table.activePulseScale : 1)
+                .onChange(of: active, initial: true) { _, isActive in
+                    if isActive, !reduceMotion {
+                        withAnimation(Theme.Motion.pulse) { pulsing = true }
+                    } else {
+                        withAnimation(Theme.Motion.overlay) { pulsing = false }
                     }
-                    .font(.system(.caption2, design: .monospaced)).lineLimit(1).minimumScaleFactor(0.7)
                 }
-            }
-            Spacer(minLength: 0)
+                .padding(.vertical, Theme.Table.activeRingGap)
+            Text(model.seatNames[seat]).font(.headline).lineLimit(1).minimumScaleFactor(0.6)
+            badges
         }
-        .padding(.horizontal, 4).padding(.vertical, 6)
+        .padding(.horizontal, 4).padding(.vertical, 2)
         .frame(width: width)
-        // No fill: the name, backs and badges sit straight on the felt; only the seat to act gets a ring.
-        .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous).stroke(.gold, lineWidth: active ? 2 : 0))
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(model.seatSummary(for: seat))
+    }
+
+    /// One line, always the same height, so the tiles do not jump when a call lands or the phase turns.
+    private var badges: some View {
+        HStack(spacing: 6) {
+            if hand.phase == .bidding {
+                // The call as a badge on the same dark pill as the auction's own buttons; a pass is muted
+                // so the bids stand out. No badge until the seat has spoken: the halo says who is deciding.
+                if let call = hand.auction.calls.last(where: { $0.seat == seat }), let label = model.latestCall(for: seat) {
+                    Text(label).font(.caption.weight(.semibold)).foregroundStyle(.ivory)
+                        .padding(.horizontal, 8).padding(.vertical, 2)
+                        .background(Theme.Wood.inlay, in: Capsule())
+                        .opacity(call.bid == nil ? 0.7 : 1)
+                }
+            } else {
+                // The stack's thickness says roughly how many cards are left; there is no number (spec R20).
+                ZStack(alignment: .leading) {
+                    ForEach(0..<min(3, max(1, hand.hands[seat].count)), id: \.self) { index in
+                        CardBackView(width: Theme.Table.seatBackWidth).offset(x: Double(index) * 3)
+                    }
+                }
+                .padding(.trailing, 6)
+                .dynamicTypeSize(...Theme.Card.maximumTypeSize)
+            }
+            if hand.auction.dealer == seat { Text("DEALER").foregroundStyle(.gold) }
+            if hand.auction.winner == seat, hand.phase != .bidding { Text("BIDDER").opacity(0.7) }
+        }
+        .font(.system(.caption2, design: .monospaced)).lineLimit(1).minimumScaleFactor(0.6)
+        .frame(height: backWidth * Theme.Card.ratio + 2)
     }
 
     private var portrait: Portrait { Cast.opponent(at: seat)?.portrait ?? model.settings.playerPortrait }

--- a/Sources/CatchFiveUI/TableSurface.swift
+++ b/Sources/CatchFiveUI/TableSurface.swift
@@ -197,12 +197,11 @@ struct TableSurface: View {
     }
 
     /// A tertiary control: a 28pt circle inside a 44pt hit area.
+    /// A bare glyph with a soft shadow for contrast, no plate (spec R19); the hit area stays 48 pt.
     private func smallButton(_ symbol: String, label: String, action: @escaping () -> Void) -> some View {
         Button(action: action) {
-            Image(systemName: symbol).font(.body)
-                .frame(width: Theme.Table.statusButtonSize, height: Theme.Table.statusButtonSize)
-                .background(.ivory.opacity(0.1), in: Circle())
-                .overlay(Circle().stroke(.ivory.opacity(0.35)))
+            Image(systemName: symbol).font(.title3.weight(.medium))
+                .shadow(color: .black.opacity(0.45), radius: 1.5, y: 1)
                 .frame(width: Theme.Table.statusButtonHitSize, height: Theme.Table.statusButtonHitSize)
                 .contentShape(Rectangle())
         }

--- a/Sources/CatchFiveUI/TableSurface.swift
+++ b/Sources/CatchFiveUI/TableSurface.swift
@@ -92,7 +92,8 @@ struct TableSurface: View {
         let pile = pile
         ZStack {
             // Reserve the pile's footprint so the layout does not jump between phases.
-            Color.clear.frame(width: TableLayout.pileReservation, height: Theme.Card.pileWidth * Theme.Card.ratio + 48)
+            Color.clear.frame(width: TableLayout.pileReservation,
+                              height: Theme.Card.pileWidth * Theme.Card.ratio + Theme.Table.partnerNudge + Theme.Table.ownNudge + 8)
             ForEach(pile.plays, id: \.card) { play in
                 Button { model.explain(play, inLastTrick: pile.isLast) } label: {
                     CardView(card: play.card, width: Theme.Card.pileWidth, style: .pile)
@@ -390,10 +391,10 @@ struct SeatView: View {
     /// when a badge applies. Laid out sideways so a row of seats costs the height of one portrait, not a
     /// stack of four lines; that is what leaves the auction its bottom row of controls (spec R21).
     var body: some View {
-        HStack(alignment: .center, spacing: 8) {
+        HStack(alignment: .center, spacing: 6) {
             PortraitView(portrait: portrait, size: Theme.Table.portraitSize, expression: SeatMood.expression(for: seat, in: model.match))
             VStack(alignment: .leading, spacing: 2) {
-                Text(model.seatNames[seat]).font(.headline).lineLimit(1).minimumScaleFactor(0.7)
+                Text(model.seatNames[seat]).font(.headline).lineLimit(1).minimumScaleFactor(0.6)
                 if hand.phase == .bidding {
                     Text(model.latestCall(for: seat) ?? "Waiting").font(.caption).opacity(0.75).lineLimit(1).minimumScaleFactor(0.8)
                 } else {
@@ -420,7 +421,7 @@ struct SeatView: View {
             }
             Spacer(minLength: 0)
         }
-        .padding(.horizontal, 6).padding(.vertical, 6)
+        .padding(.horizontal, 4).padding(.vertical, 6)
         .frame(width: width)
         // No fill: the name, backs and badges sit straight on the felt; only the seat to act gets a ring.
         .overlay(RoundedRectangle(cornerRadius: 12, style: .continuous).stroke(.gold, lineWidth: active ? 2 : 0))

--- a/Sources/CatchFiveUI/TableSurface.swift
+++ b/Sources/CatchFiveUI/TableSurface.swift
@@ -327,7 +327,7 @@ struct TableSurface: View {
 
     /// Four suit pills, each named for newcomers and captioned with what choosing it keeps and draws.
     /// Suits alternate red and black, ♥ ♠ ♦ ♣, so the two red suits never sit side by side (spec R13).
-    static let trumpOrder: [Suit] = [.hearts, .spades, .diamonds, .clubs]
+    nonisolated static let trumpOrder: [Suit] = [.hearts, .spades, .diamonds, .clubs]
 
     private var trumpChoice: some View {
         HStack(alignment: .top, spacing: Theme.Table.auctionButtonSpacing) {

--- a/Sources/CatchFiveUI/TableSurface.swift
+++ b/Sources/CatchFiveUI/TableSurface.swift
@@ -22,6 +22,8 @@ struct TableSurface: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     /// The hint's full reason, opened from its Why? control (spec R22).
     @State private var showHintDetail = false
+    /// The column's own height, measured so the table can tell whether it fits the surface (spec R25).
+    @State private var contentHeight = 0.0
 
     private var hand: Hand { model.match.hand }
 
@@ -39,15 +41,17 @@ struct TableSurface: View {
     var body: some View {
         GeometryReader { geometry in
             let reach = CGSize(width: geometry.size.width / 2 + 40, height: geometry.size.height / 2 + 40)
-            // Scrolls only when the content cannot fit, which happens at accessibility text sizes.
+            // Space goes by priority (spec R25): the seats and the pile hold the top of the table, the
+            // status line with its controls and commentary sits down by the hand, and whatever the phase
+            // leaves over opens up between them. The column is stretched to the surface whenever its
+            // content fits; when it cannot, at accessibility text sizes, it keeps its own height and scrolls.
+            let fits = contentHeight <= geometry.size.height + 0.5
             ScrollView(.vertical, showsIndicators: false) {
-                // Three groups spread over the full height: the contract under the header, the seats and
-                // pile in the middle, and the status line with its controls down by the hand.
                 VStack(spacing: 6) {
-                    Spacer(minLength: 4)
                     SeatView(model: model, seat: 2).accessibilitySortPriority(20)
                     // The side tiles give way before the pile can touch them (`TableLayout`); in the auction
-                    // there is no pile, so they keep their full width.
+                    // there is no pile, so they keep their full width. Faces sit level with the pile's centre,
+                    // each beside the card its seat played.
                     let sideWidth = inAuction ? Theme.Table.seatTileWidth : TableLayout.sideSeatWidth(available: geometry.size.width)
                     HStack(alignment: .center) {
                         SeatView(model: model, seat: 1, width: sideWidth).accessibilitySortPriority(30)
@@ -62,8 +66,10 @@ struct TableSurface: View {
                     if model.isHumanTurn, hand.phase == .choosingTrump { trumpChoice }
                     commentary
                 }
+                .padding(.top, Theme.Table.seatInset)
+                .onGeometryChange(for: Double.self) { $0.size.height } action: { contentHeight = $0 }
                 .frame(width: geometry.size.width)
-                .frame(minHeight: geometry.size.height)
+                .frame(height: fits ? geometry.size.height : nil)
             }
             .scrollBounceBehavior(.basedOnSize)
             .frame(width: geometry.size.width, height: geometry.size.height)

--- a/Sources/CatchFiveUI/TableSurface.swift
+++ b/Sources/CatchFiveUI/TableSurface.swift
@@ -112,7 +112,7 @@ struct TableSurface: View {
                 .zIndex(Double(pile.plays.firstIndex(where: { $0.card == play.card }) ?? 0))
             }
             if pile.plays.isEmpty, hand.phase == .playing, !model.isHumanTurn || hand.completedTricks.isEmpty {
-                Text(hand.completedTricks.isEmpty ? "First lead" : "").font(.caption2).opacity(0.35)
+                Text(hand.completedTricks.isEmpty ? "First lead" : "").font(.caption2).opacity(0.7)
             }
         }
         .accessibilitySortPriority(5)
@@ -301,7 +301,7 @@ struct TableSurface: View {
                 Text("You: \(call)").font(.footnote).opacity(0.85)
             } else if !inAuction {
                 Text(pile.plays.isEmpty ? " " : (reopenedTrick != nil ? "Tap a card to see why it was played" : "Tap a card on the table to see why it was played"))
-                    .font(.footnote).foregroundStyle(.ivory.opacity(0.5))
+                    .font(.footnote).foregroundStyle(.ivory.opacity(0.7))
                     .accessibilityHidden(true)
             }
         }

--- a/Sources/CatchFiveUI/TableSurface.swift
+++ b/Sources/CatchFiveUI/TableSurface.swift
@@ -323,11 +323,17 @@ struct TableSurface: View {
     }
 
     /// Four suit pills, each named for newcomers and captioned with what choosing it keeps and draws.
+    /// Suits alternate red and black, ♥ ♠ ♦ ♣, so the two red suits never sit side by side (spec R13).
+    static let trumpOrder: [Suit] = [.hearts, .spades, .diamonds, .clubs]
+
     private var trumpChoice: some View {
         HStack(alignment: .top, spacing: Theme.Table.auctionButtonSpacing) {
-            ForEach(Suit.allCases, id: \.self) { suit in
+            ForEach(Self.trumpOrder, id: \.self) { suit in
                 VStack(spacing: 2) {
-                    actionButton(suit.glyph, action: .chooseTrump(suit), fill: suit.pillFill, font: .largeTitle.weight(.bold))
+                    // The glyph carries the suit's colour on the same dark pill as every other choice; a red
+                    // fill only hid the glyph (spec R13).
+                    actionButton(suit.glyph, action: .chooseTrump(suit), font: .largeTitle.weight(.bold),
+                                 labelColor: suit.isRed ? Color.suitRed : .ivory)
                         .accessibilityLabel("\(suit.rawValue), \(model.trumpPreview(for: suit) ?? "")")
                     // One short caption line so the auction still fits without scrolling (D34): the suit and
                     // what it keeps; the draw count is implied and VoiceOver reads the full preview.
@@ -342,10 +348,10 @@ struct TableSurface: View {
 
     /// Pills fill their column so neighbours almost touch: solid, tall, with a large label.
     private func actionButton(_ label: String, action: PlayerAction, fill: Color = Theme.Wood.inlay,
-                              font: Font = .title3.weight(.semibold)) -> some View {
+                              font: Font = .title3.weight(.semibold), labelColor: Color = .ivory) -> some View {
         // One dry run per pill: the reason, when there is one, is also why the pill is greyed.
         let reason = model.validationMessage(for: action)
-        return Button { model.send(action) } label: { Text(label).font(font) }
+        return Button { model.send(action) } label: { Text(label).font(font).foregroundStyle(labelColor) }
             .buttonStyle(PillButtonStyle(fill: fill))
             .disabled(reason != nil)
             // A greyed pill still says why it is greyed to assistive technology.
@@ -455,8 +461,6 @@ struct SeatView: View {
 
 extension Suit {
     var isRed: Bool { self == .hearts || self == .diamonds }
-    /// Pill fill for a suit choice: the red suits get a deep red, the black suits the inlay.
-    var pillFill: Color { isRed ? Color(red: 0.56, green: 0.13, blue: 0.15) : Theme.Wood.inlay }
 }
 
 extension Color {

--- a/Sources/CatchFiveUI/TableView.swift
+++ b/Sources/CatchFiveUI/TableView.swift
@@ -82,12 +82,12 @@ public struct TableView: View {
         VStack(spacing: 6) {
             ScoreBarView(us: model.match.scores[0], them: model.match.scores[1],
                          usLabel: teamLabel(0), themLabel: teamLabel(1),
-                         handNumber: model.match.handNumber,
+                         contract: contractChip,
                          canUndo: model.canUndo, onUndo: { model.undo() },
                          onScores: { showScoreboard = true }, onSettings: { showSettings = true },
                          onStatistics: { showStatistics = true }, onTutorial: { showTutorial = true },
                          onNewGame: { confirmNewGame = true }, onLeave: onLeave)
-                .padding(.horizontal, 16).padding(.top, 4).padding(.bottom, 14)
+                .padding(.horizontal, 16).padding(.top, 2).padding(.bottom, 8)
                 // A solid header band: runs up behind the status bar and ends in a frown, the corners
                 // hanging lower than the middle, so the scores sit on one colour and the wood starts beneath.
                 .background {
@@ -193,6 +193,14 @@ public struct TableView: View {
             .confirmationDialog("Start over? This replaces your saved game.", isPresented: $confirmNewGame) {
                 Button("Start new game", role: .destructive) { model.newGame() }
             }
+    }
+
+    /// The header's contract chip: the bid and bidder once the auction has resolved, trump once named.
+    private var contractChip: ScoreBarView.Contract? {
+        let auction = model.match.hand.auction
+        guard auction.nextSeat == nil, let bidder = auction.winner, let bid = auction.highestBid else { return nil }
+        return ScoreBarView.Contract(trump: model.match.hand.trump, bid: bid, isNineAndOut: auction.isNineAndOut,
+                                     bidder: model.seatNames[bidder])
     }
 
     private func teamLabel(_ team: Int) -> String {

--- a/Sources/CatchFiveUI/Theme.swift
+++ b/Sources/CatchFiveUI/Theme.swift
@@ -95,6 +95,8 @@ public enum Theme {
         public static let tossDrift = 6.0
         /// Seat tiles share one width; their height follows the phase (call text in the auction, backs in play).
         public static let seatTileWidth = 116.0
+        /// Air between the header's edge and the partner's halo; the seats hold the top of the table (spec R25).
+        public static let seatInset = 10.0
         /// The status-line glyph buttons (last trick, hint): hit area; the glyph itself has no plate.
         public static let statusButtonHitSize = 48.0
         /// The deck in the table's top-right corner.

--- a/Sources/CatchFiveUI/Theme.swift
+++ b/Sources/CatchFiveUI/Theme.swift
@@ -100,7 +100,7 @@ public enum Theme {
         public static let auctionButtonSpacing = 6.0
         public static let auctionButtonRadius = 14.0
         /// The header band's bottom edge is a frown: the corners hang this much lower than the middle.
-        public static let headerDip = 26.0
+        public static let headerDip = 18.0
     }
 
     public enum Motion {

--- a/Sources/CatchFiveUI/Theme.swift
+++ b/Sources/CatchFiveUI/Theme.swift
@@ -92,8 +92,6 @@ public enum Theme {
         public static let deckWidth = 38.0
         /// How far above the fan the deck sits, for the deal-in flight.
         public static let deckRise = 520.0
-        /// The discard pile sits this far below the deck; discards fly there when trump is named.
-        public static let discardDrop = 72.0
         /// Bid, pass and suit pills: full column width, solid, well above the 44 pt minimum.
         public static let auctionButtonHeight = 64.0
         public static let auctionButtonSpacing = 6.0

--- a/Sources/CatchFiveUI/Theme.swift
+++ b/Sources/CatchFiveUI/Theme.swift
@@ -86,8 +86,7 @@ public enum Theme {
         public static let tossDrift = 6.0
         /// Seat tiles share one width; their height follows the phase (call text in the auction, backs in play).
         public static let seatTileWidth = 116.0
-        /// The round status-line buttons (last trick, hint): visible disc and hit area.
-        public static let statusButtonSize = 38.0
+        /// The status-line glyph buttons (last trick, hint): hit area; the glyph itself has no plate.
         public static let statusButtonHitSize = 48.0
         /// The deck in the table's top-right corner.
         public static let deckWidth = 38.0

--- a/Sources/CatchFiveUI/Theme.swift
+++ b/Sources/CatchFiveUI/Theme.swift
@@ -79,8 +79,17 @@ public enum Theme {
         /// The pile's reserved footprint around a card, so the table does not jump between tricks.
         public static let pileMarginX = 64.0
         public static let pileMarginY = 48.0
-        public static let seatBackWidth = 30.0
-        public static let portraitSize = 36.0
+        /// The little stack of backs under a seat's name in play: a hint of a hand, not a count (spec R20).
+        public static let seatBackWidth = 14.0
+        /// Faces around the table read at a glance from arm's length: 1.67× the 36 pt they started at (spec R2).
+        public static let portraitSize = 60.0
+        /// The tutorial's lesson tiles keep the smaller face so three of them still share a row.
+        public static let tutorialPortraitSize = 36.0
+        /// The seat to act wears a gold halo: a ring this wide, this far outside the portrait, that pulses
+        /// gently to `activePulseScale` unless motion is reduced (spec R2).
+        public static let activeRingWidth = 3.0
+        public static let activeRingGap = 4.0
+        public static let activePulseScale = 1.05
         /// A played card lands with its own small turn and drift, like a card tossed in by hand.
         public static let tossRotationDegrees = 11.0
         public static let tossDrift = 6.0
@@ -107,6 +116,8 @@ public enum Theme {
         public static let overlay = Animation.spring(duration: 0.35, bounce: 0)
         /// Reduce Motion replaces every flight with this crossfade.
         public static let reduced = Animation.easeInOut(duration: 0.2)
+        /// The halo on the seat to act breathes in and out for as long as that seat is deciding.
+        public static let pulse = Animation.easeInOut(duration: 1.2).repeatForever(autoreverses: true)
         /// How long a finished trick stays on the table, winner ringed, before it collapses.
         public static let trickHold: Duration = .milliseconds(900)
         public static let shakeAmplitude = 6.0

--- a/Sources/CatchFiveUI/Theme.swift
+++ b/Sources/CatchFiveUI/Theme.swift
@@ -73,9 +73,9 @@ public enum Theme {
 
     public enum Table {
         /// How far a played card is nudged from the pile's centre toward its seat.
-        public static let sideNudge = 38.0
-        public static let partnerNudge = 28.0
-        public static let ownNudge = 30.0
+        public static let sideNudge = 48.0
+        public static let partnerNudge = 42.0
+        public static let ownNudge = 42.0
         /// The pile's reserved footprint around a card, so the table does not jump between tricks.
         public static let pileMarginX = 64.0
         public static let pileMarginY = 48.0
@@ -83,7 +83,7 @@ public enum Theme {
         public static let portraitSize = 36.0
         /// A played card lands with its own small turn and drift, like a card tossed in by hand.
         public static let tossRotationDegrees = 11.0
-        public static let tossDrift = 9.0
+        public static let tossDrift = 6.0
         /// Seat tiles share one width; their height follows the phase (call text in the auction, backs in play).
         public static let seatTileWidth = 116.0
         /// The round status-line buttons (last trick, hint): visible disc and hit area.

--- a/Sources/CatchFiveUI/Tutorial/TutorialView.swift
+++ b/Sources/CatchFiveUI/Tutorial/TutorialView.swift
@@ -133,7 +133,7 @@ struct SeatTile: View {
     var body: some View {
         Button(action: action) {
             VStack(spacing: 4) {
-                if let portrait { PortraitView(portrait: portrait, size: Theme.Table.portraitSize) }
+                if let portrait { PortraitView(portrait: portrait, size: Theme.Table.tutorialPortraitSize) }
                 Text(name).font(.subheadline.weight(.semibold))
                 Text(detail).font(.caption).opacity(0.7)
                 if let badge { Text(badge).font(.system(.caption2, design: .monospaced)).foregroundStyle(.gold) }

--- a/Sources/CatchFiveUI/WelcomeCard.swift
+++ b/Sources/CatchFiveUI/WelcomeCard.swift
@@ -1,15 +1,16 @@
 import CatchFive
 import SwiftUI
 
-/// The returning player's card, shown over the dimmed table at launch and from the table's chevron:
-/// who you are, then Continue game (until the match is won), New match and Settings. No history, no lessons;
-/// those stay in the table's gear menu.
+/// The pause card, shown over the dimmed table at launch and from the table's Home control: who you are,
+/// then exactly three actions (spec R32). Continue game (until the match is won) is primary, New match asks
+/// first, and Main menu keeps the match and goes to the menu, where Settings, the lessons, statistics and
+/// the build explainer live.
 struct WelcomeCard: View {
     @ObservedObject var model: GameModel
     let onPlay: () -> Void
+    /// Leaves the table for the main menu with the match preserved.
+    let onMenu: () -> Void
     @State private var confirmNewMatch = false
-    @State private var showSettings = false
-    @State private var showExplainer = false
 
     var body: some View {
         VStack(spacing: 20) {
@@ -38,8 +39,7 @@ struct WelcomeCard: View {
                 } else {
                     prominent("New match") { model.newGame(); onPlay() }
                 }
-                plain("Settings") { showSettings = true }
-                plain("How Catch 5 is built") { showExplainer = true }
+                plain("Main menu", action: onMenu)
             }
         }
         .padding(22)
@@ -49,19 +49,29 @@ struct WelcomeCard: View {
         .shadow(color: .black.opacity(0.5), radius: 24, y: 12)
         .foregroundStyle(.ivory)
         .padding(24)
-        .sheet(isPresented: $showSettings) { SettingsView(settings: $model.settings) }
-        .fullScreenCoverOrSheet(isPresented: $showExplainer) { ExplainerView { showExplainer = false } }
         .confirmationDialog("Start over? This replaces your saved game.", isPresented: $confirmNewMatch) {
             Button("Start new match", role: .destructive) { model.newGame(); onPlay() }
         }
     }
 
     private func prominent(_ label: String, action: @escaping () -> Void) -> some View {
+        MenuButtons.prominent(label, action: action)
+    }
+
+    private func plain(_ label: String, action: @escaping () -> Void) -> some View {
+        MenuButtons.plain(label, action: action)
+    }
+}
+
+/// The menu's two buttons, shared by the pause card and the main menu: one gold primary per screen, and
+/// bordered ivory for the rest.
+enum MenuButtons {
+    static func prominent(_ label: String, action: @escaping () -> Void) -> some View {
         Button(action: action) { Text(label).font(.headline).frame(maxWidth: .infinity).frame(minHeight: 48) }
             .buttonStyle(.borderedProminent).tint(.gold).foregroundStyle(.black)
     }
 
-    private func plain(_ label: String, action: @escaping () -> Void) -> some View {
+    static func plain(_ label: String, action: @escaping () -> Void) -> some View {
         Button(action: action) { Text(label).frame(maxWidth: .infinity).frame(minHeight: 44) }
             .buttonStyle(.bordered).tint(.ivory.opacity(0.8))
     }

--- a/Sources/CatchFiveUI/WelcomeCard.swift
+++ b/Sources/CatchFiveUI/WelcomeCard.swift
@@ -64,8 +64,8 @@ struct WelcomeCard: View {
 }
 
 /// The menu's two buttons, shared by the pause card and the main menu: one gold primary per screen, and
-/// bordered ivory for the rest.
-enum MenuButtons {
+/// bordered ivory for the rest. On the main actor because the button styles are (CI's Swift 6.1 checks this).
+@MainActor enum MenuButtons {
     static func prominent(_ label: String, action: @escaping () -> Void) -> some View {
         Button(action: action) { Text(label).font(.headline).frame(maxWidth: .infinity).frame(minHeight: 48) }
             .buttonStyle(.borderedProminent).tint(.gold).foregroundStyle(.black)

--- a/Tests/CatchFiveUITests/GameModelTests.swift
+++ b/Tests/CatchFiveUITests/GameModelTests.swift
@@ -1059,3 +1059,10 @@ import Testing
     #expect(model.revision == before.3)
     #expect(try Data(contentsOf: url) == before.4)
 }
+
+@Test func hintSplitsIntoARecommendationAndItsReason() {
+    let parts = TableSurface.hintParts("Play the six of clubs: partner's queen of clubs holds the trick, so the most valuable card goes to it.")
+    #expect(parts.recommendation == "Play the six of clubs")
+    #expect(parts.detail == "Partner's queen of clubs holds the trick, so the most valuable card goes to it.")
+    #expect(TableSurface.hintParts("Pass").recommendation == "Pass" && TableSurface.hintParts("Pass").detail.isEmpty)
+}

--- a/Tests/CatchFiveUITests/GameModelTests.swift
+++ b/Tests/CatchFiveUITests/GameModelTests.swift
@@ -725,7 +725,9 @@ import Testing
     defer { try? FileManager.default.removeItem(at: url) }
     let model = GameModel(match: try Match(deck: GameModel.deck(), dealer: 3))
     try finishMatch(model)
-    #expect(model.match.actionCount > 100)
+    // A finished match is at least two full hands of bids, trump and plays; the deck is shuffled, so the
+    // exact length varies and a short match must not fail the timing check it exists for.
+    #expect(model.match.actionCount >= 58)
     try MatchSave.write(model.match, to: url)
     let clock = ContinuousClock()
     let elapsed = try clock.measure { _ = try MatchSave.read(from: url) }
@@ -1066,3 +1068,4 @@ import Testing
     #expect(parts.detail == "Partner's queen of clubs holds the trick, so the most valuable card goes to it.")
     #expect(TableSurface.hintParts("Pass").recommendation == "Pass" && TableSurface.hintParts("Pass").detail.isEmpty)
 }
+

--- a/Tests/CatchFiveUITests/GameModelTests.swift
+++ b/Tests/CatchFiveUITests/GameModelTests.swift
@@ -589,6 +589,17 @@ import Testing
     #expect(TableLayout.sideSeatWidth(available: 600) == Theme.Table.seatTileWidth)
 }
 
+@Test func seatTilesHoldTheLargerFaceAndItsHaloOnEveryVerifiedWidth() {
+    // Faces grew to at least 1.6× their first size (spec R2) and, with the halo at full breath, still fit
+    // inside the narrowest tile the pile row can hand a side seat.
+    #expect(Theme.Table.portraitSize >= 36 * 1.6)
+    let halo = Theme.Table.portraitSize * Theme.Table.activePulseScale + 2 * Theme.Table.activeRingGap
+    for available in [361.0, 343.0] {
+        #expect(TableLayout.sideSeatWidth(available: available) >= halo + 8)
+    }
+    #expect(TableLayout.minimumSeatWidth >= halo + 8)
+}
+
 @MainActor @Test func validationMessagesExplainRefusalsWithoutChangingTheMatch() throws {
     let deck = Suit.allCases.flatMap { suit in Rank.allCases.map { Card(suit, $0) } }
     let model = GameModel(match: try Match(deck: deck, dealer: 3))

--- a/Tests/CatchFiveUITests/GameModelTests.swift
+++ b/Tests/CatchFiveUITests/GameModelTests.swift
@@ -925,15 +925,17 @@ import Testing
     #expect(model.match.hand.legalMoves(seat: 0).allSatisfy { $0.suit == led })
 }
 
-@Test func discardsFlyToThePileUnderTheDeck() {
-    // Discards head for the top-right corner like the deal, but land lower: under the deck, not on it.
+@Test func discardsFlyToThePileOnTheLeft() {
+    // Discards head for the top-left corner, level with the deck in the top-right; the two never share a corner.
     for index in 0..<6 {
         let deal = HandFanView.dealOrigin(index: index, count: 6, width: 360)
         let discard = HandFanView.discardTarget(index: index, count: 6, width: 360)
-        #expect(discard.width == deal.width)             // same corner
-        #expect(discard.height < 0 && discard.height > deal.height)   // upward, but not as far
+        #expect(discard.width < deal.width)              // the other side of the table
+        #expect(discard.height == deal.height)           // the same height, the top of the table
     }
-    #expect(Theme.Table.discardDrop > Theme.Table.deckWidth * Theme.Card.ratio)   // clear of the deck itself
+    // The leftmost card barely moves sideways; the rightmost crosses most of the table.
+    #expect(HandFanView.discardTarget(index: 0, count: 6, width: 360).width > -40)
+    #expect(HandFanView.discardTarget(index: 5, count: 6, width: 360).width < -300)
 }
 
 @Test func dealerDrawPicksTheHighestCardWithSuitsBreakingTies() {

--- a/Tests/CatchFiveUITests/GameModelTests.swift
+++ b/Tests/CatchFiveUITests/GameModelTests.swift
@@ -1069,3 +1069,9 @@ import Testing
     #expect(TableSurface.hintParts("Pass").recommendation == "Pass" && TableSurface.hintParts("Pass").detail.isEmpty)
 }
 
+
+@Test func deckThicknessFollowsTheStockWithoutShowingANumber() {
+    #expect(DeckView.thickness(0) == 1 && DeckView.thickness(6) == 1)
+    #expect(DeckView.thickness(7) == 2 && DeckView.thickness(18) == 3)
+    #expect(DeckView.thickness(28) == 5 && DeckView.thickness(52) == 5)
+}

--- a/Tests/CatchFiveUITests/GameModelTests.swift
+++ b/Tests/CatchFiveUITests/GameModelTests.swift
@@ -1075,3 +1075,9 @@ import Testing
     #expect(DeckView.thickness(7) == 2 && DeckView.thickness(18) == 3)
     #expect(DeckView.thickness(28) == 5 && DeckView.thickness(52) == 5)
 }
+
+@Test func trumpChoicesAlternateRedAndBlack() {
+    let order = TableSurface.trumpOrder
+    #expect(Set(order) == Set(Suit.allCases) && order.count == 4)
+    for pair in zip(order, order.dropFirst()) { #expect(pair.0.isRed != pair.1.isRed) }
+}


### PR DESCRIPTION
## Summary

Sixteen bite-sized commits from the UI/UX redesign spec (Passes 1 and 2, plus the first of Pass 3), each verified on the "Catch 5 Wood" simulator (iPhone 16 Pro, 402×874) with fixture screenshots. Docs were deliberately left untouched for this pass; see the debt list below.

**Pass 1 — clipping, unreadable tricks, live vs review**
- R21: every bidding row fits on screen; the fan's frame follows its arrangement.
- R23: wider pile nudges so all four played cards are identifiable, winner ringed.
- R24: "Reviewing last trick" with a "‹ Back to play" control; live and review wording never mix.
- R22: hints show one complete recommendation with a "Why?" sheet for the reason.
- R26: muted table text meets 4.5:1 on the lit felt.

**Pass 2 — simplify the table and fit every phase**
- R20: no card counts anywhere; the deck and discard stack show thickness only.
- R1: one-row header with a score chip and a contract chip beside the gear.
- Home: a bare chevron and label back to the pause card (no plate, per R16).
- R19: status-line icons are bare glyphs with a shadow, 48 pt hit areas.
- R13: trump choices run ♥ ♠ ♦ ♣, suit colour on the glyph.
- R3: the discard pile sits top-left, mirroring the deck; discards fly there.
- R2: faces grow to 60 pt in portrait-over-name tiles; the seat to act wears a breathing gold halo (static under Reduce Motion); calls are badges under the name.
- R25: the table column fills the surface when it fits, so seats and pile hold the top and the status line and controls sit by the hand; it scrolls from the top at accessibility text sizes.
- R4 and R12 needed no change.

**Pass 3 (start) — navigation**
- R29/R31/R32 (part): a `MainMenuView` screen (player, saved-match line, Continue game, New match, Settings, How to play, Statistics, How Catch 5 is built). The pause card keeps exactly Continue game, New match and Main menu. Launch still lands on the table under the card; moving launch to the main menu is the next R32 step.

## Verification
- `swift test`: 148 tests pass (three new: hint splitting, deck thickness, trump order; one new layout invariant for the larger faces; one flaky replay-length assertion relaxed).
- `scripts/build-simulator.py` after every commit; screenshots of auction, trump, mid-trick, trick review, hand end and the accessibility-size scroll fallback.
- Installed on the phone from c9acd93 via `scripts/install-phone.sh`.

## Not done here
- `docs/types-and-functions.md`, `docs/decisions.md` (from D56) and `docs/testing.md` still need rows for `HintDetailView`, `TableSurface.hintParts`, `ScoreBarView.Contract`, `TableSurface.trumpOrder`, `DeckView.thickness`, `MainMenuView`, `MenuButtons` and the new `Theme` tokens, then `python3 scripts/export-docs.py --app`.
- `fix/labelled-home-button` is pushed for reference only; its two commits are already in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
