### PR TITLE
Three-element header, launch on the main menu, modest faces, beginner mode first cut (R1, R2, R14, R32)

### DIFF
--- a/Sources/CatchFiveUI/MainMenuView.swift
+++ b/Sources/CatchFiveUI/MainMenuView.swift
@@ -90,8 +90,9 @@ struct MainMenuView: View {
         .sheet(isPresented: $showTutorial, onDismiss: { model.markRulesSeen() }) { TutorialView(model: tutorial) { showTutorial = false } }
         .sheet(isPresented: $showStatistics) { StatisticsView(stats: model.statistics, records: model.records) { showStatistics = false } }
         .fullScreenCoverOrSheet(isPresented: $showExplainer) { ExplainerView { showExplainer = false } }
-        .confirmationDialog("Start over? This replaces your saved game.", isPresented: $confirmNewMatch) {
+        .confirmationDialog("Start over? This replaces your saved game.", isPresented: $confirmNewMatch, titleVisibility: .visible) {
             Button("Start new match", role: .destructive) { model.newGame(); onPlay() }
+            Button("Cancel", role: .cancel) {}
         }
     }
 }

--- a/Sources/CatchFiveUI/MainMenuView.swift
+++ b/Sources/CatchFiveUI/MainMenuView.swift
@@ -43,6 +43,17 @@ struct MainMenuView: View {
                 .background(.white.opacity(0.05), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
                 .accessibilityElement(children: .combine)
 
+                // One setting for guidance (spec R14): on adds hints and explanations, off is a clean table.
+                Toggle(isOn: $model.settings.beginnerMode) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Beginner mode").font(.headline)
+                        Text("Hints and guided play").font(.footnote).opacity(0.75)
+                    }
+                }
+                .tint(.gold)
+                .padding(.horizontal, 16).padding(.vertical, 12)
+                .background(.white.opacity(0.05), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+
                 VStack(spacing: 10) {
                     if model.match.winner == nil {
                         MenuButtons.prominent("Continue game", action: onPlay)

--- a/Sources/CatchFiveUI/RootView.swift
+++ b/Sources/CatchFiveUI/RootView.swift
@@ -1,40 +1,38 @@
 import SwiftUI
 
 /// Owns the one `GameModel`. A new player sees login, then the tutorial as an intro they may skip, then the
-/// table. A returning player lands on the table with a small pause card over it; Main menu on that card, and
-/// Continue game on the menu, move between the menu and the table with the match preserved (spec R31, R32).
+/// table. A returning player lands on the main menu, Continue game one tap away; the table's menu opens a
+/// pause card whose Main menu comes back here with the match preserved (spec R31, R32).
 public struct RootView: View {
     enum Screen { case login, intro, menu, table }
 
     @StateObject private var model: GameModel
     @StateObject private var tutorial: TutorialModel
     @State private var screen: Screen
-    /// The returning player's card; also reopened by the table's chevron.
-    @State private var showWelcome: Bool
+    /// The pause card over the table, opened from the table's menu.
+    @State private var showWelcome = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.colorSchemeContrast) private var contrast
 
     public init(model: GameModel) {
         _model = StateObject(wrappedValue: model)
         _tutorial = StateObject(wrappedValue: model.makeTutorial())
-        let first = Self.initialScreen(for: model.settings)
-        _screen = State(initialValue: first)
-        _showWelcome = State(initialValue: first == .table)
+        _screen = State(initialValue: Self.initialScreen(for: model.settings))
     }
 
-    /// Login until a name is saved; the intro until it has been seen or skipped; then the table, with the
-    /// welcome card over it.
+    /// Login until a name is saved; the intro until it has been seen or skipped; then the main menu, never
+    /// a popup over the table (spec R32).
     nonisolated static func initialScreen(for settings: Settings) -> Screen {
         if !settings.hasSignedIn { return .login }
-        return settings.hasSeenRules ? .table : .intro
+        return settings.hasSeenRules ? .menu : .intro
     }
 
-    enum Destination: Equatable { case welcome, intro, table }
+    enum Destination: Equatable { case menu, intro, table }
 
     /// Where New match on the sign-in screen leads. An older install that already has a match in progress
-    /// keeps it and gets the welcome card, so nothing is thrown away without a choice.
+    /// keeps it and gets the main menu, so nothing is thrown away without a choice.
     nonisolated static func destinationAfterSignIn(matchInProgress: Bool, hasSeenRules: Bool) -> Destination {
-        if matchInProgress { return .welcome }
+        if matchInProgress { return .menu }
         return hasSeenRules ? .table : .intro
     }
 
@@ -81,7 +79,7 @@ public struct RootView: View {
     private func startFirstMatch() {
         if model.match.winner != nil { model.newGame() }
         switch Self.destinationAfterSignIn(matchInProgress: model.matchInProgress, hasSeenRules: model.settings.hasSeenRules) {
-        case .welcome: showWelcome = true; show(.table)
+        case .menu: showWelcome = false; show(.menu)
         case .intro: showWelcome = false; show(.intro)
         case .table: showWelcome = false; show(.table)
         }

--- a/Sources/CatchFiveUI/ScoreBarView.swift
+++ b/Sources/CatchFiveUI/ScoreBarView.swift
@@ -1,10 +1,10 @@
 import CatchFive
 import SwiftUI
 
-/// The bar pinned above the table, one row (spec R1): the way home, a score chip that opens the score
-/// sheet, the contract chip once bidding has resolved, and the menu. Nothing else lives up here; the
-/// hand number is on the score sheet, the seat to act is ringed at the table, and the dealer badge sits
-/// on the hand's label.
+/// The bar pinned above the table, one row of three (spec R1): a score chip that opens the score sheet,
+/// the contract chip once bidding has resolved, and the menu, which is also where the game pauses (spec
+/// R32). Nothing else lives up here; the hand number is on the score sheet, the seat to act is ringed at
+/// the table, and the dealer badge sits on the hand's label.
 struct ScoreBarView: View {
     /// What the contract chip shows: the bid and who holds it, plus trump once it is named.
     struct Contract: Equatable {
@@ -26,25 +26,11 @@ struct ScoreBarView: View {
     let onStatistics: () -> Void
     let onTutorial: () -> Void
     let onNewGame: () -> Void
-    let onLeave: () -> Void
+    /// Opens the pause card over the table.
+    let onPause: () -> Void
 
     var body: some View {
         HStack(spacing: 10) {
-            // Chevron and word, no plate (spec R16): the way back to the welcome card reads as a button
-            // because it says where it goes, not because it is boxed.
-            Button(action: onLeave) {
-                HStack(spacing: 4) {
-                    Image(systemName: "chevron.left").font(.subheadline.weight(.bold))
-                    Text("Home").font(.subheadline.weight(.semibold))
-                }
-                .shadow(color: .black.opacity(0.35), radius: 1, y: 1)
-                .frame(minHeight: 44)
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Home")
-            .accessibilityHint("Shows the welcome card: continue this game, start a new match, or open Settings")
-
             Button(action: onScores) {
                 HStack(spacing: 4) {
                     Text("Us").opacity(0.7)
@@ -67,6 +53,7 @@ struct ScoreBarView: View {
             Spacer(minLength: 4)
 
             Menu {
+                Button("Pause game", systemImage: "pause.circle", action: onPause)
                 Button("Undo last action", systemImage: "arrow.uturn.backward", action: onUndo).disabled(!canUndo)
                 Divider()
                 Button("Settings", systemImage: "gearshape", action: onSettings)

--- a/Sources/CatchFiveUI/Settings.swift
+++ b/Sources/CatchFiveUI/Settings.swift
@@ -20,6 +20,8 @@ public struct Settings: Codable, Equatable, Sendable {
     public var playerName: String?
     /// The face the human chose at login.
     public var playerPortrait: Portrait
+    /// Hints and guided play (spec R14). Off is normal mode: a clean table, no coaching, the same rules.
+    public var beginnerMode: Bool
 
     public static let defaultSeatNames = ["You"] + Cast.opponents.map(\.name)
     /// The defaults before the cast existed; files still carrying them migrate on load.
@@ -38,7 +40,7 @@ public struct Settings: Codable, Equatable, Sendable {
     public init(playSpeed: PlaySpeed = .normal, seatNames: [String] = Settings.defaultSeatNames,
                 haptics: Bool = true, difficulty: Difficulty = .standard, hasSeenRules: Bool = false,
                 completedLessons: Set<Int> = [], playerName: String? = nil,
-                playerPortrait: Portrait = Cast.defaultPlayerPortrait) {
+                playerPortrait: Portrait = Cast.defaultPlayerPortrait, beginnerMode: Bool = true) {
         self.playSpeed = playSpeed
         self.seatNames = seatNames
         self.haptics = haptics
@@ -47,6 +49,7 @@ public struct Settings: Codable, Equatable, Sendable {
         self.completedLessons = completedLessons
         self.playerName = playerName
         self.playerPortrait = playerPortrait
+        self.beginnerMode = beginnerMode
     }
 
     // Missing keys fall back to defaults so an older settings file keeps loading.
@@ -61,6 +64,8 @@ public struct Settings: Codable, Equatable, Sendable {
         completedLessons = (try? container.decodeIfPresent(Set<Int>.self, forKey: .completedLessons)) ?? nil ?? []
         playerName = (try? container.decodeIfPresent(String.self, forKey: .playerName)) ?? nil
         playerPortrait = (try? container.decodeIfPresent(Portrait.self, forKey: .playerPortrait)) ?? nil ?? Cast.defaultPlayerPortrait
+        // A file from before the setting existed keeps the guidance it always had.
+        beginnerMode = (try? container.decodeIfPresent(Bool.self, forKey: .beginnerMode)) ?? nil ?? true
         let names = (try? container.decodeIfPresent([String].self, forKey: .seatNames)) ?? nil ?? Settings.defaultSeatNames
         // Only a file from before the cast (no player name yet) still carries the direction defaults by
         // accident; after sign-in a typed "West" is a choice and stays.

--- a/Sources/CatchFiveUI/SettingsView.swift
+++ b/Sources/CatchFiveUI/SettingsView.swift
@@ -18,6 +18,11 @@ struct SettingsView: View {
                 } header: { Text("Difficulty") } footer: {
                     Text("Easy players use the original strategy and lose about two matches in three to Standard. Hints always use Standard.")
                 }
+                Section {
+                    Toggle("Beginner mode", isOn: $settings.beginnerMode)
+                } header: { Text("Assistance") } footer: {
+                    Text("Hints, tap-to-explain on the table and what each trump would keep. Off is normal mode: the same rules and a clean table.")
+                }
                 Section("Play speed") {
                     Picker("Computer pace", selection: $settings.playSpeed) {
                         Text("Relaxed").tag(Settings.PlaySpeed.relaxed)

--- a/Sources/CatchFiveUI/TableSurface.swift
+++ b/Sources/CatchFiveUI/TableSurface.swift
@@ -37,6 +37,8 @@ struct TableSurface: View {
     }
 
     private var inAuction: Bool { hand.phase == .bidding || hand.phase == .choosingTrump }
+    /// Coaching shows only in beginner mode (spec R14); rules, refusals and the record of play show in both.
+    private var coaching: Bool { model.settings.beginnerMode }
 
     var body: some View {
         GeometryReader { geometry in
@@ -105,8 +107,9 @@ struct TableSurface: View {
                             .stroke(.gold, lineWidth: pile.winner == play.seat ? 3 : 0))
                 }
                 .buttonStyle(.plain)
+                .allowsHitTesting(coaching)
                 .accessibilityLabel(model.spokenDescription(of: play, winner: pile.winner))
-                .accessibilityHint("Explains why this card was played")
+                .accessibilityHint(coaching ? "Explains why this card was played" : "")
                 .rotationEffect(.degrees(toss(for: play).rotation))
                 .offset(Self.pileOffset(for: play.seat) + toss(for: play).offset)
                 .matchedGeometryEffect(id: play.card, in: namespace)
@@ -190,7 +193,7 @@ struct TableSurface: View {
                 statusText.font(.title3.weight(.medium)).multilineTextAlignment(.center).frame(maxWidth: .infinity)
                     .lineLimit(1).minimumScaleFactor(0.7)
                     .accessibilityFocused(statusFocus)
-                if model.isHumanTurn, hand.phase != .finished {
+                if model.isHumanTurn, hand.phase != .finished, coaching {
                     smallButton("lightbulb", label: "Hint") { model.showHint() }
                 } else {
                     Spacer().frame(width: Theme.Table.statusButtonHitSize, height: Theme.Table.statusButtonHitSize)
@@ -279,7 +282,7 @@ struct TableSurface: View {
             } else if hand.phase == .bidding, !model.isHumanTurn, let call = model.latestCall(for: 0) {
                 Text("You: \(call)").font(.footnote).opacity(0.85)
             } else if !inAuction {
-                Text(pile.plays.isEmpty ? " " : (reopenedTrick != nil ? "Tap a card to see why it was played" : "Tap a card on the table to see why it was played"))
+                Text(pile.plays.isEmpty || !coaching ? " " : (reopenedTrick != nil ? "Tap a card to see why it was played" : "Tap a card on the table to see why it was played"))
                     .font(.footnote).foregroundStyle(.ivory.opacity(0.7))
                     .accessibilityHidden(true)
             }
@@ -338,9 +341,9 @@ struct TableSurface: View {
                     actionButton(suit.glyph, action: .chooseTrump(suit), font: .largeTitle.weight(.bold),
                                  labelColor: suit.isRed ? Color.suitRed : .ivory)
                         .accessibilityLabel("\(suit.rawValue), \(model.trumpPreview(for: suit) ?? "")")
-                    // One short caption line so the auction still fits without scrolling (D34): the suit and
-                    // what it keeps; the draw count is implied and VoiceOver reads the full preview.
-                    Text(model.trumpPreview(for: suit).flatMap { $0.split(separator: " · ").first }.map { "\(suit.rawValue) · \($0)" } ?? suit.rawValue)
+                    // One short caption line so the auction still fits without scrolling (D34): the suit and, in
+                    // beginner mode, what it keeps (spec R30); the draw count is implied and VoiceOver reads it all.
+                    Text(coaching ? (model.trumpPreview(for: suit).flatMap { $0.split(separator: " · ").first }.map { "\(suit.rawValue) · \($0)" } ?? suit.rawValue) : suit.rawValue)
                         .font(.caption2.weight(.semibold)).opacity(0.8)
                         .lineLimit(1).minimumScaleFactor(0.6)
                 }
@@ -448,7 +451,7 @@ struct SeatView: View {
             Text(model.seatNames[seat]).font(.headline).lineLimit(1).minimumScaleFactor(0.6)
             badges
         }
-        .padding(.horizontal, 4).padding(.vertical, 2)
+        .padding(.horizontal, 4).padding(.vertical, 1)
         .frame(width: width)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(model.seatSummary(for: seat))

--- a/Sources/CatchFiveUI/TableView.swift
+++ b/Sources/CatchFiveUI/TableView.swift
@@ -86,7 +86,7 @@ public struct TableView: View {
                          canUndo: model.canUndo, onUndo: { model.undo() },
                          onScores: { showScoreboard = true }, onSettings: { showSettings = true },
                          onStatistics: { showStatistics = true }, onTutorial: { showTutorial = true },
-                         onNewGame: { confirmNewGame = true }, onLeave: onLeave)
+                         onNewGame: { confirmNewGame = true }, onPause: onLeave)
                 .padding(.horizontal, 16).padding(.top, 2).padding(.bottom, 8)
                 // A solid header band: runs up behind the status bar and ends in a frown, the corners
                 // hanging lower than the middle, so the scores sit on one colour and the wood starts beneath.

--- a/Sources/CatchFiveUI/TableView.swift
+++ b/Sources/CatchFiveUI/TableView.swift
@@ -190,8 +190,9 @@ public struct TableView: View {
                 Button("Bid 9 and out", role: .destructive) { model.send(.nineAndOut) }
                 Button("Cancel", role: .cancel) {}
             } message: { Text("Take all nine points to win the match. Take fewer and you lose it, whatever the score.") }
-            .confirmationDialog("Start over? This replaces your saved game.", isPresented: $confirmNewGame) {
+            .confirmationDialog("Start over? This replaces your saved game.", isPresented: $confirmNewGame, titleVisibility: .visible) {
                 Button("Start new game", role: .destructive) { model.newGame() }
+                Button("Cancel", role: .cancel) {}
             }
     }
 

--- a/Sources/CatchFiveUI/Theme.swift
+++ b/Sources/CatchFiveUI/Theme.swift
@@ -81,14 +81,15 @@ public enum Theme {
         public static let pileMarginY = 48.0
         /// The little stack of backs under a seat's name in play: a hint of a hand, not a count (spec R20).
         public static let seatBackWidth = 14.0
-        /// Faces around the table read at a glance from arm's length: 1.67× the 36 pt they started at (spec R2).
-        public static let portraitSize = 60.0
+        /// Faces around the table read at a glance from arm's length: 68 pt, up from the 36 they started at
+        /// (spec R2) and a touch over the first pass's 60, the most a side tile holds beside the pile.
+        public static let portraitSize = 68.0
         /// The tutorial's lesson tiles keep the smaller face so three of them still share a row.
         public static let tutorialPortraitSize = 36.0
         /// The seat to act wears a gold halo: a ring this wide, this far outside the portrait, that pulses
         /// gently to `activePulseScale` unless motion is reduced (spec R2).
         public static let activeRingWidth = 3.0
-        public static let activeRingGap = 4.0
+        public static let activeRingGap = 3.0
         public static let activePulseScale = 1.05
         /// A played card lands with its own small turn and drift, like a card tossed in by hand.
         public static let tossRotationDegrees = 11.0
@@ -98,7 +99,7 @@ public enum Theme {
         /// Air between the header's edge and the partner's halo; the seats hold the top of the table (spec R25).
         public static let seatInset = 10.0
         /// The status-line glyph buttons (last trick, hint): hit area; the glyph itself has no plate.
-        public static let statusButtonHitSize = 48.0
+        public static let statusButtonHitSize = 44.0
         /// The deck in the table's top-right corner.
         public static let deckWidth = 38.0
         /// How far above the fan the deck sits, for the deal-in flight.

--- a/Sources/CatchFiveUI/WelcomeCard.swift
+++ b/Sources/CatchFiveUI/WelcomeCard.swift
@@ -1,10 +1,10 @@
 import CatchFive
 import SwiftUI
 
-/// The pause card, shown over the dimmed table at launch and from the table's Home control: who you are,
-/// then exactly three actions (spec R32). Continue game (until the match is won) is primary, New match asks
-/// first, and Main menu keeps the match and goes to the menu, where Settings, the lessons, statistics and
-/// the build explainer live.
+/// The pause card, shown over the dimmed table from the table's menu: exactly three actions (spec R32).
+/// Continue game (until the match is won) is primary, New match asks first, and Main menu keeps the match
+/// and goes to the menu, where Settings, the lessons, statistics and the build explainer live. No greeting
+/// and no summary: the main menu carries those.
 struct WelcomeCard: View {
     @ObservedObject var model: GameModel
     let onPlay: () -> Void
@@ -14,20 +14,11 @@ struct WelcomeCard: View {
 
     var body: some View {
         VStack(spacing: 20) {
-            HStack(spacing: 14) {
-                PortraitView(portrait: model.settings.playerPortrait, size: 48)
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("CATCH 5").font(.system(.caption2, design: .monospaced).weight(.medium)).tracking(1).opacity(0.7)
-                    Text("Welcome back, \(model.settings.playerName ?? "friend")")
-                        .font(.system(.title3, design: .serif).weight(.semibold)).lineLimit(2)
-                }
-                Spacer(minLength: 0)
+            VStack(spacing: 2) {
+                Text("CATCH 5").font(.system(.caption2, design: .monospaced).weight(.medium)).tracking(1).opacity(0.7)
+                Text("Paused").font(.system(.title3, design: .serif).weight(.semibold))
             }
             .accessibilityElement(children: .combine)
-
-            if let context = model.resumeContext {
-                Text(context).font(.footnote).opacity(0.8).frame(maxWidth: .infinity, alignment: .leading)
-            }
 
             VStack(spacing: 10) {
                 if model.match.winner == nil {

--- a/Sources/CatchFiveUI/WelcomeCard.swift
+++ b/Sources/CatchFiveUI/WelcomeCard.swift
@@ -40,8 +40,9 @@ struct WelcomeCard: View {
         .shadow(color: .black.opacity(0.5), radius: 24, y: 12)
         .foregroundStyle(.ivory)
         .padding(24)
-        .confirmationDialog("Start over? This replaces your saved game.", isPresented: $confirmNewMatch) {
+        .confirmationDialog("Start over? This replaces your saved game.", isPresented: $confirmNewMatch, titleVisibility: .visible) {
             Button("Start new match", role: .destructive) { model.newGame(); onPlay() }
+            Button("Cancel", role: .cancel) {}
         }
     }
 

--- a/Tests/CatchFiveUITests/GameModelTests.swift
+++ b/Tests/CatchFiveUITests/GameModelTests.swift
@@ -589,6 +589,16 @@ import Testing
     #expect(TableLayout.sideSeatWidth(available: 600) == Theme.Table.seatTileWidth)
 }
 
+@Test func beginnerModeIsOnByDefaultAndForOlderSettingsFiles() throws {
+    // Guidance is the app's original behaviour, so a settings file from before the switch keeps it (spec R14).
+    #expect(Settings().beginnerMode)
+    let older = try JSONDecoder().decode(Settings.self, from: Data(#"{"playerName":"Connor"}"#.utf8))
+    #expect(older.beginnerMode)
+    var normal = Settings(); normal.beginnerMode = false
+    let round = try JSONDecoder().decode(Settings.self, from: try JSONEncoder().encode(normal))
+    #expect(!round.beginnerMode)
+}
+
 @Test func seatTilesHoldTheLargerFaceAndItsHaloOnEveryVerifiedWidth() {
     // Faces grew to at least 1.6× their first size (spec R2) and, with the halo at full breath, still fit
     // inside the tile the pile row hands a side seat on the verified widths (iPhone 16 Pro and 16, less

--- a/Tests/CatchFiveUITests/GameModelTests.swift
+++ b/Tests/CatchFiveUITests/GameModelTests.swift
@@ -509,7 +509,7 @@ import Testing
 
 @MainActor @Test func rootOpensOnLoginUntilSignedInThenOnTheTable() {
     #expect(RootView.initialScreen(for: Settings()) == .login)
-    #expect(RootView.initialScreen(for: Settings(hasSeenRules: true, playerName: "Connor")) == .table)
+    #expect(RootView.initialScreen(for: Settings(hasSeenRules: true, playerName: "Connor")) == .menu)
 }
 
 
@@ -591,13 +591,13 @@ import Testing
 
 @Test func seatTilesHoldTheLargerFaceAndItsHaloOnEveryVerifiedWidth() {
     // Faces grew to at least 1.6× their first size (spec R2) and, with the halo at full breath, still fit
-    // inside the narrowest tile the pile row can hand a side seat.
+    // inside the tile the pile row hands a side seat on the verified widths (iPhone 16 Pro and 16, less
+    // the table's inset).
     #expect(Theme.Table.portraitSize >= 36 * 1.6)
     let halo = Theme.Table.portraitSize * Theme.Table.activePulseScale + 2 * Theme.Table.activeRingGap
-    for available in [361.0, 343.0] {
+    for available in [370.0, 361.0] {
         #expect(TableLayout.sideSeatWidth(available: available) >= halo + 8)
     }
-    #expect(TableLayout.minimumSeatWidth >= halo + 8)
 }
 
 @MainActor @Test func validationMessagesExplainRefusalsWithoutChangingTheMatch() throws {
@@ -791,14 +791,14 @@ import Testing
     var settings = Settings(playerName: "Connor")
     #expect(RootView.initialScreen(for: settings) == .intro)   // signed in, never saw the intro or rules
     settings.hasSeenRules = true
-    #expect(RootView.initialScreen(for: settings) == .table)
+    #expect(RootView.initialScreen(for: settings) == .menu)
     #expect(RootView.initialScreen(for: Settings()) == .login)
 }
 
 @Test func signingInKeepsAMatchAnExistingInstallLeftInProgress() {
-    // An older install with a saved match reaches the welcome card, not a silent new deal.
-    #expect(RootView.destinationAfterSignIn(matchInProgress: true, hasSeenRules: true) == .welcome)
-    #expect(RootView.destinationAfterSignIn(matchInProgress: true, hasSeenRules: false) == .welcome)
+    // An older install with a saved match reaches the main menu, not a silent new deal.
+    #expect(RootView.destinationAfterSignIn(matchInProgress: true, hasSeenRules: true) == .menu)
+    #expect(RootView.destinationAfterSignIn(matchInProgress: true, hasSeenRules: false) == .menu)
     #expect(RootView.destinationAfterSignIn(matchInProgress: false, hasSeenRules: false) == .intro)
     #expect(RootView.destinationAfterSignIn(matchInProgress: false, hasSeenRules: true) == .table)
 }


### PR DESCRIPTION
## Summary

Follows PR #39. Reconciles the header, launch flow and pause card with the spec's R1, R2 and R32 as reconciled in the September 6 working agreement, and adds the first cut of R14 beginner mode.

- **Header back to three elements (R1, R32):** the Home control leaves the bar; "Pause game" is the gear menu's first item and opens the pause card, which now reads "Paused" with exactly Continue game, New match and Main menu.
- **Launch on the main menu (R32):** a returning player lands on the main menu with Continue game primary; no popup over the table. Main menu → Continue game restores the match untouched (verified by pixel comparison of the table before and after).
- **Faces a touch larger (R2):** 60 → 68 pt in the established partner-across seating; halo gap, tile padding and status-glyph hit size trimmed so every bidding row still fits. The single-row 120 pt experiment was built and reverted at Connor's request.
- **Beginner mode (R14, first cut):** `Settings.beginnerMode`, on by default and for older files; toggles on the main menu and in Settings. Off: no hint bulb, no tap-to-explain or its instruction line, plain suit names under the trump pills (R30). Refusals and the record of play stay in both modes. Not included: the tracking tray, discard warnings, strategy review.
- **New match dialogs** show their question and a Cancel.

## Verification (Wood simulator, iPhone 16 Pro 402×874, default text size unless noted)
- `swift test`: 149 pass.
- Auction, trump and play fit in both modes; the toggle flips both ways and persists (`settings.json` read back); difficulty and the saved match unchanged after toggling.
- Pause → Continue resumes identically; pause → Main menu → Continue game restores; New match cancel (tap outside) preserves; New match confirm deals a fresh match.
- Returning-player relaunch lands on the main menu with Continue game.
- Hamburger shows Settings, Statistics, How Catch 5 is built in that order; Settings opened and its toggle works.
- Observed once: a tap on the "Start new match" popover resumed the old match instead (the popover overlaps Continue game); a second attempt worked. Not reproduced; worth a finger test on the phone.

## Not run
Statistics and How Catch 5 is built destinations from the hamburger (dropdown verified, destinations not opened this session); first-run onboarding regression; large text sizes on this branch; Reduce Motion; VoiceOver; legal-move feedback interactively (covered by `validationMessagesExplainRefusalsWithoutChangingTheMatch`; the refusal line is not gated by mode).

## Docs
Still owed, with PR #39's: types rows (`MainMenuView`, `MenuButtons`, `Settings.beginnerMode`, theme tokens), decisions from D56, testing counts, then `scripts/export-docs.py --app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
